### PR TITLE
fix(ai-controller): add 2000 character max-length guard on queryBuilder prompt

### DIFF
--- a/apps/dashboard-api/src/controllers/ai.controller.js
+++ b/apps/dashboard-api/src/controllers/ai.controller.js
@@ -25,8 +25,8 @@ const queryBuilder = async (req, res, next) => {
         if (!safeCollectionName || !safePrompt) {
             throw new AppError(400, "Collection name and prompt are required");
         }
-        if (safePrompt.length > 2000) {
-           throw new AppError(400, "Prompt exceeds the maximum allowed length of 2000 characters");
+        if (safePrompt.length > 1000) {
+           throw new AppError(400, "Prompt exceeds the maximum allowed length of 1000 characters");
        }
 
         if (safeCollectionName === 'users') {

--- a/apps/dashboard-api/src/controllers/ai.controller.js
+++ b/apps/dashboard-api/src/controllers/ai.controller.js
@@ -25,6 +25,9 @@ const queryBuilder = async (req, res, next) => {
         if (!safeCollectionName || !safePrompt) {
             throw new AppError(400, "Collection name and prompt are required");
         }
+        if (safePrompt.length > 2000) {
+           throw new AppError(400, "Prompt exceeds the maximum allowed length of 2000 characters");
+       }
 
         if (safeCollectionName === 'users') {
             throw new AppError(403, "Cannot query the users collection via AI");


### PR DESCRIPTION
Closes #247

## Problem
The `queryBuilder` controller validated that `prompt` was a non-empty
string but applied no upper-bound limit. This allowed arbitrarily large
prompts to be forwarded directly to the AI service, consuming unbounded
token quota per request.

## Fix
Added a length check on `safePrompt` after trimming. Prompts exceeding
2000 characters are rejected with HTTP 400 before any AI service call
is made.

## Changes
- `apps/dashboard-api/src/controllers/ai.controller.js`: added max-length
  guard in `queryBuilder` after the empty-string check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to enforce a 2000-character limit on prompts. Requests exceeding this limit will now return an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->