### PR TITLE
fix: align auth schema validation with dashboard api

### DIFF
--- a/apps/public-api/src/controllers/userAuth.controller.js
+++ b/apps/public-api/src/controllers/userAuth.controller.js
@@ -184,7 +184,6 @@ const isRequiredField = (required) =>
     required === 1 ||
     String(required).trim().toLowerCase() === "true" ||
     String(required).trim() === "1";
-    
 const assertAuthProjectReady = (project) => {
     if (!project?.isAuthEnabled) {
         const err = new Error('Authentication service is disabled');
@@ -200,13 +199,24 @@ const assertAuthProjectReady = (project) => {
         throw err;
     }
 
-    const hasEmail = usersCollection.model.find(
+    const model = usersCollection.model;
+
+    if (!Array.isArray(model)) {
+        const err = new Error('Invalid Users Schema');
+        err.statusCode = 422;
+        err.publicMessage =
+            "The 'users' collection must contain required 'email' and 'password' String fields.";
+        throw err;
+    }
+
+    const hasEmail = model.some(
         (f) =>
             normalizeFieldKey(f.key).toLowerCase() === "email" &&
             normalizeFieldType(f.type) === "string" &&
             isRequiredField(f.required)
     );
-    const hasPassword = usersCollection.model.find(
+
+    const hasPassword = model.some(
         (f) =>
             normalizeFieldKey(f.key).toLowerCase() === "password" &&
             normalizeFieldType(f.type) === "string" &&

--- a/apps/public-api/src/controllers/userAuth.controller.js
+++ b/apps/public-api/src/controllers/userAuth.controller.js
@@ -168,6 +168,23 @@ const getGooglePublicKeys = async () => {
  * @param {Object} project - Lean project document
  * @returns {Object} The users collection config
  */
+
+const normalizeFieldKey = (key) =>
+    String(key || "")
+        .replace(/\uFEFF/g, "")
+        .trim();
+
+const normalizeFieldType = (type) =>
+    String(type || "")
+        .trim()
+        .toLowerCase();
+
+const isRequiredField = (required) =>
+    required === true ||
+    required === 1 ||
+    String(required).trim().toLowerCase() === "true" ||
+    String(required).trim() === "1";
+    
 const assertAuthProjectReady = (project) => {
     if (!project?.isAuthEnabled) {
         const err = new Error('Authentication service is disabled');
@@ -183,8 +200,19 @@ const assertAuthProjectReady = (project) => {
         throw err;
     }
 
-    const hasEmail = usersCollection.model.find(f => f.key === 'email' && f.type === 'String' && f.required);
-    const hasPassword = usersCollection.model.find(f => f.key === 'password' && f.type === 'String' && f.required);
+    const hasEmail = usersCollection.model.find(
+        (f) =>
+            normalizeFieldKey(f.key).toLowerCase() === "email" &&
+            normalizeFieldType(f.type) === "string" &&
+            isRequiredField(f.required)
+    );
+    const hasPassword = usersCollection.model.find(
+        (f) =>
+            normalizeFieldKey(f.key).toLowerCase() === "password" &&
+            normalizeFieldType(f.type) === "string" &&
+            isRequiredField(f.required)
+    );
+
     if (!hasEmail || !hasPassword) {
         const err = new Error('Invalid Users Schema');
         err.statusCode = 422;


### PR DESCRIPTION
## Summary

This PR fixes an authentication schema validation mismatch between the Dashboard API and the Public API.

The Dashboard API validates required authentication fields (`email` and `password`) using normalized, case-insensitive comparisons, while the Public API previously performed strict case-sensitive checks. As a result, schemas accepted by the Dashboard could later be rejected by authentication endpoints in the Public API.

## Changes

* Added `normalizeFieldKey()` helper.
* Added `normalizeFieldType()` helper.
* Added `isRequiredField()` helper.
* Updated `assertAuthProjectReady()` to use normalized validation for:

  * Field keys (`email`, `password`)
  * Field types (`String`, `string`, `STRING`)
  * Required field values (`true`, `"true"`, `1`)

## Root Cause

Dashboard API validation:

```js
normalizeFieldKey(f.key).toLowerCase() === "email"
normalizeFieldType(f.type) === "string"
isRequiredField(f.required)
```

Public API validation:

```js
f.key === "email"
f.type === "String"
f.required
```

This inconsistency allowed schemas to pass Dashboard validation but fail during authentication requests.

## Fix

The Public API now applies the same normalization logic used by the Dashboard API, ensuring both services enforce the same validation contract.

## Verification

* Verified syntax using:

```bash
node --check apps/public-api/src/controllers/userAuth.controller.js
```

* Confirmed validation now accepts:

  * `Email`, `EMAIL`, `email`
  * `String`, `string`, `STRING`
  * `true`, `"true"`, `1`

* Confirmed authentication schema validation behavior is now consistent across both services.

Fixes #281


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication validation to normalize field names and types and to interpret varied "required" flag formats, ensuring email and password fields are reliably detected despite formatting or casing differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->