### PR TITLE
Standarized the API Response in Public-Api middleware

### DIFF
--- a/apps/public-api/src/__tests__/authorizeReadOperation.test.js
+++ b/apps/public-api/src/__tests__/authorizeReadOperation.test.js
@@ -1,7 +1,20 @@
 'use strict';
 
-const authorizeReadOperation = require('../middlewares/authorizeReadOperation');
+jest.mock('@urbackend/common', () => {
+    class MockAppError extends Error {
+        constructor(statusCode, message, error) {
+            super(message);
+            this.statusCode = statusCode;
+            this.error = error;
+            this.isOperational = true;
+        }
+    }
+    return {
+        AppError: MockAppError
+    };
+});
 
+const authorizeReadOperation = require('../middlewares/authorizeReadOperation');
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -80,9 +93,8 @@ describe('authorizeReadOperation middleware', () => {
 
         await authorizeReadOperation(req, res, next);
 
-        expect(res.statusCode).toBe(404);
-        expect(res.body.error).toBe('Collection not found');
-        expect(next).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 404, message: 'Collection not found' }));
+        expect(res.status).not.toHaveBeenCalled();
     });
 
     test('rls disabled allows public read', async () => {
@@ -121,9 +133,8 @@ describe('authorizeReadOperation middleware', () => {
 
         await authorizeReadOperation(req, res, next);
 
-        expect(res.statusCode).toBe(401);
-        expect(res.body.error).toBe('Authentication required');
-        expect(next).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401, message: 'Provide a valid user Bearer token for private reads.' }));
+        expect(res.status).not.toHaveBeenCalled();
     });
 
     test('private mode sets owner filter when authed', async () => {

--- a/apps/public-api/src/__tests__/authorizeWriteOperation.test.js
+++ b/apps/public-api/src/__tests__/authorizeWriteOperation.test.js
@@ -8,20 +8,31 @@ const mockFindById = jest.fn();
 const mockSelect = jest.fn();
 const mockLean = jest.fn();
 
-jest.mock('@urbackend/common', () => ({
-    getConnection: jest.fn().mockResolvedValue({}),
-    getCompiledModel: jest.fn().mockReturnValue({
-        findById: (...args) => {
-            mockFindById(...args);
-            return {
-                select: (field) => {
-                    mockSelect(field);
-                    return { lean: mockLean };
-                },
-            };
-        },
-    }),
-}));
+jest.mock('@urbackend/common', () => {
+    class MockAppError extends Error {
+        constructor(statusCode, message, error) {
+            super(message);
+            this.statusCode = statusCode;
+            this.error = error;
+            this.isOperational = true;
+        }
+    }
+    return {
+        AppError: MockAppError,
+        getConnection: jest.fn().mockResolvedValue({}),
+        getCompiledModel: jest.fn().mockReturnValue({
+            findById: (...args) => {
+                mockFindById(...args);
+                return {
+                    select: (field) => {
+                        mockSelect(field);
+                        return { lean: mockLean };
+                    },
+                };
+            },
+        }),
+    };
+});
 
 jest.mock('mongoose', () => ({
     Types: {
@@ -138,10 +149,8 @@ describe('authorizeWriteOperation middleware', () => {
 
             await authorizeWriteOperation(req, res, next);
 
-            expect(res.statusCode).toBe(403);
-            expect(res.body.success).toBe(false);
-            expect(res.body.error).toBe('Write blocked for publishable key');
-            expect(next).not.toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403, error: 'Write blocked for publishable key' }));
+            expect(res.status).not.toHaveBeenCalled();
         });
 
         test('blocked with 401 when RLS enabled but no auth token provided', async () => {
@@ -150,10 +159,8 @@ describe('authorizeWriteOperation middleware', () => {
 
             await authorizeWriteOperation(req, res, next);
 
-            expect(res.statusCode).toBe(401);
-            expect(res.body.success).toBe(false);
-            expect(res.body.error).toBe('Authentication required');
-            expect(next).not.toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }));
+            expect(res.status).not.toHaveBeenCalled();
         });
     });
 
@@ -171,10 +178,8 @@ describe('authorizeWriteOperation middleware', () => {
 
             await authorizeWriteOperation(req, res, next);
 
-            expect(res.statusCode).toBe(403);
-            expect(res.body.success).toBe(false);
-            expect(res.body.error).toBe('RLS owner mismatch');
-            expect(next).not.toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403, error: 'RLS owner mismatch' }));
+            expect(res.status).not.toHaveBeenCalled();
         });
 
         // In the new atomic design, the middleware does not block based on document owner
@@ -293,10 +298,8 @@ describe('authorizeWriteOperation middleware', () => {
 
             await authorizeWriteOperation(req, res, next);
 
-            expect(res.statusCode).toBe(404);
-            expect(res.body.success).toBe(false);
-            expect(res.body.error).toBe('Collection not found');
-            expect(next).not.toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 404, error: 'Collection not found' }));
+            expect(res.status).not.toHaveBeenCalled();
         });
 
         test('returns 403 when RLS ownerField is _id for a POST insert', async () => {
@@ -325,10 +328,8 @@ describe('authorizeWriteOperation middleware', () => {
 
             await authorizeWriteOperation(req, res, next);
 
-            expect(res.statusCode).toBe(403);
-            expect(res.body.success).toBe(false);
-            expect(res.body.error).toBe('Insert denied');
-            expect(next).not.toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403, error: 'Insert denied' }));
+            expect(res.status).not.toHaveBeenCalled();
         });
 
         test('returns 400 for an invalid document id on PUT', async () => {
@@ -342,10 +343,8 @@ describe('authorizeWriteOperation middleware', () => {
 
             await authorizeWriteOperation(req, res, next);
 
-            expect(res.statusCode).toBe(400);
-            expect(res.body.success).toBe(false);
-            expect(res.body.error).toBe('Invalid ID format.');
-            expect(next).not.toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400, error: 'Invalid ID format' }));
+            expect(res.status).not.toHaveBeenCalled();
         });
 
 
@@ -361,10 +360,8 @@ describe('authorizeWriteOperation middleware', () => {
 
             await authorizeWriteOperation(req, res, next);
 
-            expect(res.statusCode).toBe(403);
-            expect(res.body.success).toBe(false);
-            expect(res.body.error).toBe('Owner field immutable');
-            expect(next).not.toHaveBeenCalled();
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403, error: 'Owner field immutable' }));
+            expect(res.status).not.toHaveBeenCalled();
         });
     });
 });

--- a/apps/public-api/src/__tests__/verifyApiKey.test.js
+++ b/apps/public-api/src/__tests__/verifyApiKey.test.js
@@ -5,18 +5,29 @@ const mockSelect = jest.fn().mockReturnThis();
 const mockPopulate = jest.fn().mockReturnThis();
 const mockLean = jest.fn();
 
-jest.mock('@urbackend/common', () => ({
-    Project: {
-        findOne: jest.fn(() => ({
-            select: mockSelect,
-            populate: mockPopulate,
-            lean: mockLean,
-        })),
-    },
-    hashApiKey: jest.fn((key) => `hashed_${key}`),
-    getProjectByApiKeyCache: jest.fn().mockResolvedValue(null),
-    setProjectByApiKeyCache: jest.fn().mockResolvedValue(undefined),
-}));
+jest.mock('@urbackend/common', () => {
+    class MockAppError extends Error {
+        constructor(statusCode, message, error) {
+            super(message);
+            this.statusCode = statusCode;
+            this.error = error;
+            this.isOperational = true;
+        }
+    }
+    return {
+        AppError: MockAppError,
+        Project: {
+            findOne: jest.fn(() => ({
+                select: mockSelect,
+                populate: mockPopulate,
+                lean: mockLean,
+            })),
+        },
+        hashApiKey: jest.fn((key) => `hashed_${key}`),
+        getProjectByApiKeyCache: jest.fn().mockResolvedValue(null),
+        setProjectByApiKeyCache: jest.fn().mockResolvedValue(undefined),
+    };
+});
 
 const { hashApiKey, getProjectByApiKeyCache, Project } = require('@urbackend/common');
 const verifyApiKey = require('../middlewares/verifyApiKey');
@@ -100,9 +111,8 @@ describe('verifyApiKey middleware', () => {
 
         await verifyApiKey(req, res, next);
 
-        expect(next).not.toHaveBeenCalled();
-        expect(res.status).toHaveBeenCalledWith(401);
-        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'API key not found' }));
+        expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401, message: 'API key not found' }));
+        expect(res.status).not.toHaveBeenCalled();
     });
 
     test('header takes precedence when both x-api-key header and ?key= query param are present', async () => {
@@ -139,9 +149,8 @@ describe('verifyApiKey middleware', () => {
 
         await verifyApiKey(req, res, next);
 
-        expect(next).not.toHaveBeenCalled();
-        expect(res.status).toHaveBeenCalledWith(401);
-        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'API key not found' }));
+        expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401, message: 'API key not found' }));
+        expect(res.status).not.toHaveBeenCalled();
     });
 
     test('returns 401 when project is not found in DB', async () => {
@@ -151,9 +160,8 @@ describe('verifyApiKey middleware', () => {
 
         await verifyApiKey(req, res, next);
 
-        expect(next).not.toHaveBeenCalled();
-        expect(res.status).toHaveBeenCalledWith(401);
-        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'API key is expired or invalid.' }));
+        expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401, error: 'API key is expired or invalid.' }));
+        expect(res.status).not.toHaveBeenCalled();
     });
 
     test('returns 401 when owner is not verified', async () => {
@@ -163,9 +171,8 @@ describe('verifyApiKey middleware', () => {
 
         await verifyApiKey(req, res, next);
 
-        expect(next).not.toHaveBeenCalled();
-        expect(res.status).toHaveBeenCalledWith(401);
-        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Owner not verified' }));
+        expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401, error: 'Owner not verified' }));
+        expect(res.status).not.toHaveBeenCalled();
     });
 
     test('uses cache when available and does not query DB', async () => {

--- a/apps/public-api/src/middlewares/authorizeReadOperation.js
+++ b/apps/public-api/src/middlewares/authorizeReadOperation.js
@@ -40,6 +40,7 @@ module.exports = async (req, res, next) => {
 
         return next(new AppError(403, 'Unsupported RLS mode'));
     } catch (err) {
-        return next(new AppError(500, err.message, 'Internal Server Error'));
+        console.error('[authorizeReadOperation] Unexpected error:', err);
+        return next(new AppError(500, 'Internal Server Error'));
     }
 };

--- a/apps/public-api/src/middlewares/authorizeReadOperation.js
+++ b/apps/public-api/src/middlewares/authorizeReadOperation.js
@@ -1,3 +1,4 @@
+const { AppError } = require('@urbackend/common');
 module.exports = async (req, res, next) => {
     try {
         if (req.keyRole === 'secret') {
@@ -10,7 +11,7 @@ module.exports = async (req, res, next) => {
         const collectionConfig = project.collections.find(c => c.name === collectionName);
 
         if (!collectionConfig) {
-            return res.status(404).json({ error: 'Collection not found' });
+            return next(new AppError(404, 'Collection not found'));
         }
 
         const rls = collectionConfig.rls || {};
@@ -24,10 +25,7 @@ module.exports = async (req, res, next) => {
 
         if (mode === 'private') {
             if (!req.authUser?.userId) {
-                return res.status(401).json({
-                    error: 'Authentication required',
-                    message: 'Provide a valid user Bearer token for private reads.'
-                });
+                return next(new AppError(401, 'Provide a valid user Bearer token for private reads.', 'Authentication required'));
             }
 
             const ownerField = rls.ownerField || 'userId';
@@ -40,8 +38,8 @@ module.exports = async (req, res, next) => {
             return next();
         }
 
-        return res.status(403).json({ error: 'Unsupported RLS mode' });
+        return next(new AppError(403, 'Unsupported RLS mode'));
     } catch (err) {
-        return res.status(500).json({ error: err.message });
+        return next(new AppError(500, err.message, 'Internal Server Error'));
     }
 };

--- a/apps/public-api/src/middlewares/authorizeWriteOperation.js
+++ b/apps/public-api/src/middlewares/authorizeWriteOperation.js
@@ -96,6 +96,7 @@ for (let i = 0; i < bodyItems.length; i++) {
 
         return next();
     } catch (err) {
-        return next(new AppError(500, err.message, 'Internal Server Error'));
+        console.error('[authorizeWriteOperation] Unexpected error:', err);
+        return next(new AppError(500, 'Internal Server Error'));
     }
 };

--- a/apps/public-api/src/middlewares/authorizeWriteOperation.js
+++ b/apps/public-api/src/middlewares/authorizeWriteOperation.js
@@ -1,3 +1,4 @@
+const { AppError } = require('@urbackend/common');
 const { getConnection } = require('@urbackend/common');
 const { getCompiledModel } = require('@urbackend/common');
 const mongoose = require('mongoose');
@@ -13,40 +14,28 @@ module.exports = async (req, res, next) => {
         const collectionConfig = project.collections.find(c => c.name === collectionName);
 
         if (!collectionConfig) {
-            return res.status(404).json({ success: false, error: 'Collection not found', message: 'The requested collection does not exist.' });
+            return next(new AppError(404, 'The requested collection does not exist.', 'Collection not found'));
         }
 
         const rls = collectionConfig.rls || {};
         if (!rls.enabled) {
-            return res.status(403).json({
-                success: false,
-                error: 'Write blocked for publishable key',
-                message: 'Enable RLS for this collection to allow publishable-key writes.'
-            });
+            return next(new AppError(403, 'Enable RLS for this collection to allow publishable-key writes.', 'Write blocked for publishable key'));
         }
 
         if (rls.requireAuthForWrite && !req.authUser?.userId) {
-            return res.status(401).json({
-                success: false,
-                error: 'Authentication required',
-                message: 'Provide a valid user Bearer token for write operations.'
-            });
+            return next(new AppError(401, 'Provide a valid user Bearer token for write operations.', 'Authentication required'));
         }
 
         const modeRaw = rls.mode || 'public-read';
         const allowedModes = new Set(['public-read', 'private', 'owner-write-only']);
         if (!allowedModes.has(modeRaw)) {
-            return res.status(403).json({ success: false, error: 'Unsupported RLS mode', message: 'The collection RLS mode is invalid.' });
+            return next(new AppError(403, 'The collection RLS mode is invalid.', 'Unsupported RLS mode'));
         }
 
         const ownerField = rls.ownerField || 'userId';
 
         if (!req.authUser?.userId) {
-            return res.status(401).json({
-                success: false,
-                error: 'Authentication required',
-                message: 'Provide a valid user Bearer token for write operations.'
-            });
+            return next(new AppError(401, 'Provide a valid user Bearer token for write operations.', 'Authentication required'));
         }
 
         const authUserId = String(req.authUser.userId);
@@ -54,32 +43,20 @@ module.exports = async (req, res, next) => {
 
         if (method === 'POST') {
             if (ownerField === '_id') {
-                return res.status(403).json({
-                    success: false,
-                    error: 'Insert denied',
-                    message: "RLS ownerField '_id' is not valid for insert ownership checks."
-                });
+                return next(new AppError(403, "RLS ownerField '_id' is not valid for insert ownership checks.", 'Insert denied'));
             }
 
             const bodyItems = Array.isArray(req.body) ? req.body : [req.body];
 
           if (bodyItems.length === 0) {
-    return res.status(400).json({
-        success: false,
-        error: 'Invalid request body',
-        message: 'Request body cannot be an empty array.'
-    });
+    return next(new AppError(400, 'Request body cannot be an empty array.', 'Invalid request body'));
 }
 
 for (let i = 0; i < bodyItems.length; i++) {
     const item = bodyItems[i];
 
     if (!item || typeof item !== 'object' || Array.isArray(item)) {
-        return res.status(400).json({
-            success: false,
-            error: 'Invalid request body',
-            message: `Item at index ${i} must be a valid object`
-        });
+        return next(new AppError(400, `Item at index ${i} must be a valid object`, 'Invalid request body'));
     }
 
     const incomingOwner = item?.[ownerField];
@@ -90,11 +67,7 @@ for (let i = 0; i < bodyItems.length; i++) {
     }
 
     if (String(incomingOwner) !== authUserId) {
-        return res.status(403).json({
-            success: false,
-            error: 'RLS owner mismatch',
-            message: `Item at index ${i} must have ${ownerField} equal to your user id`
-        });
+        return next(new AppError(403, `Item at index ${i} must have ${ownerField} equal to your user id`, 'RLS owner mismatch'));
     }
 }
 
@@ -103,7 +76,7 @@ for (let i = 0; i < bodyItems.length; i++) {
 
         if (method === 'PUT' || method === 'PATCH' || method === 'DELETE') {
             if (!id || !mongoose.Types.ObjectId.isValid(id)) {
-                return res.status(400).json({ success: false, error: 'Invalid ID format.', message: 'The provided document ID is not valid.' });
+                return next(new AppError(400, 'The provided document ID is not valid.', 'Invalid ID format'));
             }
 
             req.rlsFilter = { [ownerField]: authUserId };
@@ -114,11 +87,7 @@ for (let i = 0; i < bodyItems.length; i++) {
                     Object.prototype.hasOwnProperty.call(req.body, ownerField) &&
                     String(req.body[ownerField]) !== authUserId
                 ) {
-                    return res.status(403).json({
-                        success: false,
-                        error: 'Owner field immutable',
-                        message: `${ownerField} cannot be changed under RLS.`
-                    });
+                    return next(new AppError(403, `${ownerField} cannot be changed under RLS.`, 'Owner field immutable'));
                 }
             }
 
@@ -127,6 +96,6 @@ for (let i = 0; i < bodyItems.length; i++) {
 
         return next();
     } catch (err) {
-        return res.status(500).json({ success: false, error: 'Internal Server Error', message: err.message });
+        return next(new AppError(500, err.message, 'Internal Server Error'));
     }
 };

--- a/apps/public-api/src/middlewares/blockUsersCollectionDataAccess.js
+++ b/apps/public-api/src/middlewares/blockUsersCollectionDataAccess.js
@@ -1,11 +1,9 @@
+const { AppError } = require('@urbackend/common');
 module.exports = (req, res, next) => {
     const collectionName = String(req.params?.collectionName || '').trim().toLowerCase();
 
     if (collectionName === 'users') {
-        return res.status(403).json({
-            error: "Users collection is protected",
-            message: "Use /api/userAuth endpoints for users collection operations."
-        });
+        return next(new AppError(403, 'Use /api/userAuth endpoints for users collection operations.', 'Users collection is protected'));
     }
 
     return next();

--- a/apps/public-api/src/middlewares/projectRateLimiter.js
+++ b/apps/public-api/src/middlewares/projectRateLimiter.js
@@ -1,4 +1,5 @@
 const rateLimit = require('express-rate-limit');
+const { AppError } = require('@urbackend/common');
 
 const projectRateLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, 
@@ -12,10 +13,7 @@ const projectRateLimiter = rateLimit({
     },
 
     handler: (req, res, next, options) => {
-        res.status(options.statusCode).json({
-            error: "Too Many Requests",
-            message: "Project Rate limit exceeded. Please try again later."
-        });
+        next(new AppError(options.statusCode, "Project Rate limit exceeded. Please try again later.", "Too Many Requests"));
     },
     
     limit: async (req, res) => {

--- a/apps/public-api/src/middlewares/requireSecretKey.js
+++ b/apps/public-api/src/middlewares/requireSecretKey.js
@@ -1,8 +1,7 @@
+const { AppError } = require('@urbackend/common');
 module.exports = (req, res, next) => {
     if (req.keyRole !== 'secret') {
-        return res.status(403).json({ 
-            error: "Forbidden. This action requires a Secret Key (sk_live_...)." 
-        });
+        return next(new AppError(403, 'Forbidden. This action requires a Secret Key (sk_live_...).'));
     }
     next();
 };

--- a/apps/public-api/src/middlewares/verifyApiKey.js
+++ b/apps/public-api/src/middlewares/verifyApiKey.js
@@ -1,3 +1,4 @@
+const { AppError } = require('@urbackend/common');
 const {Project} = require('@urbackend/common');
 const { hashApiKey } = require('@urbackend/common');
 const {
@@ -22,7 +23,7 @@ module.exports = async (req, res, next) => {
         }
 
         if (!apiKey) {
-            return res.status(401).json({ error: 'API key not found' });
+            return next(new AppError(401, 'API key not found'));
         }
 
         const isSecret = apiKey.startsWith('sk_live_');
@@ -51,20 +52,14 @@ module.exports = async (req, res, next) => {
                 .lean();
 
             if (!project) {
-                return res.status(401).json({
-                    error: "API key is expired or invalid.",
-                    action: "Please use a valid API key or regenerate a new one from the dashboard."
-                });
+                return next(new AppError(401, 'Please use a valid API key or regenerate a new one from the dashboard.', 'API key is expired or invalid.'));
             }
 
             await setProjectByApiKeyCache(hashedApi, project);
         }
 
         if (!project.owner.isVerified) {
-            return res.status(401).json({
-                error: 'Owner not verified',
-                fix: 'Verify your account on https://urbackend.bitbros.in/dashboard'
-            });
+            return next(new AppError(401, 'Verify your account on https://urbackend.bitbros.in/dashboard', 'Owner not verified'));
         }
 
         if (!project.resources) project.resources = {};
@@ -77,7 +72,7 @@ module.exports = async (req, res, next) => {
 
             if (!allowedDomains.includes('*')) {
                 if (!origin) {
-                    return res.status(403).json({ error: "Forbidden: Origin header missing and this key is restricted to specific domains." });
+                    return next(new AppError(403, 'Forbidden: Origin header missing and this key is restricted to specific domains.'));
                 }
 
                 try {
@@ -100,10 +95,10 @@ module.exports = async (req, res, next) => {
                     });
 
                     if (!isAllowed) {
-                        return res.status(403).json({ error: `Forbidden: Origin ${originUrl} is not allowed by this project's CORS policy.` });
+                        return next(new AppError(403, `Forbidden: Origin ${originUrl} is not allowed by this project's CORS policy.`));
                     }
                 } catch (err) {
-                    return res.status(400).json({ error: "Invalid Origin header format." });
+                    return next(new AppError(400, 'Invalid Origin header format.'));
                 }
             }
         }
@@ -113,6 +108,6 @@ module.exports = async (req, res, next) => {
         req.keyRole = isSecret ? 'secret' : 'publishable';
         next();
     } catch (err) {
-        res.status(500).json({ error: err.message });
+        next(new AppError(500, err.message, 'Internal Server Error'));
     }
 };

--- a/apps/public-api/src/middlewares/verifyApiKey.js
+++ b/apps/public-api/src/middlewares/verifyApiKey.js
@@ -108,6 +108,7 @@ module.exports = async (req, res, next) => {
         req.keyRole = isSecret ? 'secret' : 'publishable';
         next();
     } catch (err) {
-        next(new AppError(500, err.message, 'Internal Server Error'));
+        console.error('[verifyApiKey] Unexpected error:', err);
+        next(new AppError(500, 'Internal Server Error'));
     }
 };


### PR DESCRIPTION
## 🚀 Pull Request Description

I had added AppError and AppResponse Utility to entire backend's middleware of Public-Api which provide a standard way to operate. Migrated raw JSON response with standard utility.

Fixes #237 

## 🛠️ Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement (Frontend only)
- [x] ⚙️ Refactor / Chore

## 🧪 Testing & Validation
### Backend Verification:
- [x] I have run `npm test` in the `backend/` directory and all tests passed.
- [ ] I have verified the API endpoints using Postman/Thunder Client.
- [x] New unit tests have been added (if applicable).

### Frontend Verification:
- [x] I have run `npm run lint` in the `frontend/` directory.
- [ ] Verified the UI changes on different screen sizes (Responsive).
- [ ] Checked for any console errors in the browser dev tools.

## ✅ Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or errors.
- [ ] I have updated the documentation (README/Docs) accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized error handling across public API middleware (read/write authorization, API key verification, secret-key enforcement, rate limiting, and blocked data access) to propagate failures through the centralized error flow instead of sending responses directly.
* **Tests**
  * Updated middleware tests to match the new error propagation behavior, including richer error payload assertions and adjustments to mocks so failures are validated via `next(...)` handling rather than direct response writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->