### PR TITLE
Fix/Navbar CTA button overflows on mobile screens  #290

### DIFF
--- a/apps/web-dashboard/src/pages/LandingPage/index.jsx
+++ b/apps/web-dashboard/src/pages/LandingPage/index.jsx
@@ -233,6 +233,10 @@ function LandingPage() {
             const delta = currentScrollY - lastScrollY.current;
             setScrolled(currentScrollY > 20);
 
+            if (delta > 2) {
+                setIsMobileMenuOpen(false);
+            }
+
             // Show quickly on even slight upward scroll; hide only on clear downward movement.
             if (currentScrollY < 80 || delta < -2) {
                 setIsNavVisible(true);
@@ -243,9 +247,7 @@ function LandingPage() {
             lastScrollY.current = currentScrollY;
         };
 
-        window.addEventListener('scroll', handleScroll);
-
-
+        window.addEventListener('scroll', handleScroll, { passive: true });
 
         return () => window.removeEventListener('scroll', handleScroll);
     }, []);
@@ -318,17 +320,15 @@ function LandingPage() {
                 <a href="#features" onClick={() => setIsMobileMenuOpen(false)} style={{ fontSize: '1.5rem', fontWeight: 700, color: '#fff', textDecoration: 'none' }}>Features</a>
                 <a href="#use-cases" onClick={() => setIsMobileMenuOpen(false)} style={{ fontSize: '1.5rem', fontWeight: 700, color: '#fff', textDecoration: 'none' }}>Use Cases</a>
                 <Link to="/pricing" onClick={() => setIsMobileMenuOpen(false)} style={{ fontSize: '1.5rem', fontWeight: 700, color: '#fff', textDecoration: 'none' }}>Pricing</Link>
+                <a href="https://docs.ub.bitbros.in" target="_blank" rel="noopener noreferrer" onClick={() => setIsMobileMenuOpen(false)} style={{ fontSize: '1.5rem', fontWeight: 700, color: '#fff', textDecoration: 'none' }}>Docs</a>
                 <a href="#faq" onClick={() => setIsMobileMenuOpen(false)} style={{ fontSize: '1.5rem', fontWeight: 700, color: '#fff', textDecoration: 'none' }}>FAQ</a>
                 <div style={{ height: '1px', width: '60px', background: '#333', margin: '10px 0' }}></div>
                 {isAuthenticated ? (
-                    <button onClick={() => navigate('/dashboard')} className="btn btn-primary" style={{ fontWeight: 600, width: '200px', padding: '12px' }}>
+                    <button onClick={() => { setIsMobileMenuOpen(false); navigate('/dashboard'); }} className="btn btn-primary" style={{ fontWeight: 600, width: '200px', padding: '12px' }}>
                         Go to Console
                     </button>
                 ) : (
-                    <>
-                        <Link to="/login" onClick={() => setIsMobileMenuOpen(false)} style={{ fontSize: '1.2rem', fontWeight: 500, color: '#aaa', textDecoration: 'none' }}>Log in</Link>
-                        <Link to="/signup" onClick={() => setIsMobileMenuOpen(false)} className="btn btn-primary" style={{ fontWeight: 600, padding: '12px 30px', width: '200px', textAlign: 'center' }}>Start for Free</Link>
-                    </>
+                    <Link to="/signup" onClick={() => setIsMobileMenuOpen(false)} className="btn btn-primary" style={{ fontWeight: 600, padding: '12px 30px', width: '200px', textAlign: 'center' }}>Start for Free</Link>
                 )}
             </div>
 

--- a/apps/web-dashboard/src/pages/LandingPage/style.css
+++ b/apps/web-dashboard/src/pages/LandingPage/style.css
@@ -137,13 +137,14 @@
     letter-spacing: -0.02em;
 }
 
-.nav-links {
+.nav-glass .nav-links {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    flex: 0 1 auto;
 }
 
-.nav-link {
+.nav-glass .nav-link {
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -156,23 +157,23 @@
     transition: all 0.2s ease;
 }
 
-.nav-link:hover {
+.nav-glass .nav-link:hover {
     color: #fff;
     background: rgba(255, 255, 255, 0.05);
 }
 
-.nav-link svg {
+.nav-glass .nav-link svg {
     opacity: 0.7;
 }
 
-.nav-actions {
+.nav-glass .nav-actions {
     display: flex;
     align-items: center;
     gap: 0.75rem;
     flex-shrink: 0;
 }
 
-.nav-btn-ghost {
+.nav-glass .nav-btn-ghost {
     padding: 0.5rem 1.25rem;
     color: #aaa;
     text-decoration: none;
@@ -182,12 +183,12 @@
     transition: all 0.2s ease;
 }
 
-.nav-btn-ghost:hover {
+.nav-glass .nav-btn-ghost:hover {
     color: #fff;
     background: rgba(255, 255, 255, 0.05);
 }
 
-.nav-btn-primary {
+.nav-glass .nav-btn-primary {
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -204,12 +205,12 @@
     box-shadow: 0 2px 8px rgba(0, 245, 212, 0.2);
 }
 
-.nav-btn-primary:hover {
+.nav-glass .nav-btn-primary:hover {
     transform: translateY(-1px);
     box-shadow: 0 4px 12px rgba(0, 245, 212, 0.3);
 }
 
-.mobile-menu-btn {
+.nav-glass .mobile-menu-btn {
     display: none;
     background: none;
     border: none;
@@ -218,21 +219,26 @@
     padding: 0.5rem;
 }
 
-@media(max-width: 1024px) {
-    .nav-links {
+@media (max-width: 1024px) {
+    .nav-glass .nav-links {
         display: none;
     }
-    
-    .mobile-menu-btn {
+
+    .nav-glass .mobile-menu-btn {
         display: flex;
+        align-items: center;
+        justify-content: center;
     }
-    
-    .nav-btn-ghost {
-        display: none;
-    }
-    
-    .nav-container {
+
+    .nav-glass .nav-container {
         padding: 1rem 1.5rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .nav-glass .nav-container {
+        padding: 0.75rem 1rem;
+        gap: 1rem;
     }
 }
 
@@ -1196,12 +1202,12 @@
         font-size: 2.8rem;
     }
 
-    .nav-links {
+    .nav-glass .nav-links {
         display: none;
     }
 
-    .mobile-menu-btn {
-        display: block;
+    .nav-glass .mobile-menu-btn {
+        display: flex;
     }
 
     .hero-section {
@@ -1427,11 +1433,15 @@
     align-items: center;
     gap: 2rem;
     transform: translateY(-100%);
-    transition: transform 0.3s ease-in-out;
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform 0.3s ease-in-out, visibility 0.3s ease-in-out;
 }
 
 .mobile-menu-overlay.open {
     transform: translateY(0);
+    visibility: visible;
+    pointer-events: auto;
 }
 
 /* BYOM Callout Section */


### PR DESCRIPTION

`fix#290: Navbar CTA button overflows on mobile screens`

## Description

Fixes #290

### Summary
This PR fixes the landing page navbar on mobile screens. The nav links and buttons were not laying out correctly on small screens, and some items were showing in the wrong place.

### What was wrong
- On mobile, desktop nav links (Features, Use Cases, Pricing, Docs) were still visible next to the hamburger menu.
- Global navbar styles were overriding the landing page styles.
- The closed hamburger menu could still show content over the hero section.
- **Log in** was duplicated in both the top navbar and the hamburger menu.

### What changed
- Scoped landing navbar styles under `.nav-glass` so mobile layout works correctly.
- Hide desktop nav links on small screens; keep **Log in** and **Get Started** in the top navbar.
- Add **Docs** to the hamburger menu.
- Remove **Log in** from the hamburger menu (it stays in the top bar).
- Keep **Start for Free** in the hamburger menu for signup.
- Close the hamburger menu when the user scrolls down.
- Fix the closed menu overlay so it does not show over the page.

### Mobile layout after fix
**Top navbar:** Logo · Log in · Get Started · Hamburger  

**Hamburger menu:** How it Works · Features · Use Cases · Pricing · Docs · FAQ · Start for Free


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Docs" link to mobile menu navigation
  * Mobile menu now automatically closes when scrolling

* **Improvements**
  * Enhanced mobile menu visibility and interaction handling
  * Streamlined unauthenticated user options in mobile menu (now displays "Start for Free" signup)
  * Optimized scroll event handling for better performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->