### PR TITLE
fix(project): invalidate api key cache on deletion

### DIFF
--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -2190,7 +2190,8 @@ module.exports.deleteProject = async (req, res) => {
     }).select(
       "+resources.storage.config.encrypted " +
         "+resources.storage.config.iv " +
-        "+resources.storage.config.tag",
+        "+resources.storage.config.tag " +
+        "publishableKey secretKey",
     );
 
     if (!project) {
@@ -2236,6 +2237,11 @@ module.exports.deleteProject = async (req, res) => {
 
     await MailTemplate.deleteMany({ projectId: project._id });
     await Project.deleteOne({ _id: projectId });
+
+    await deleteProjectByApiKeyCache(project.publishableKey);
+    await deleteProjectByApiKeyCache(project.secretKey);
+    await deleteProjectById(project._id.toString());
+
     storageRegistry.delete(projectId.toString());
 
     res.json({


### PR DESCRIPTION
Fixes #322

## Summary

Invalidate Redis project caches when a project is deleted.

## Changes

* Added `publishableKey` and `secretKey` to the project lookup used by `deleteProject()`.
* Invalidated API-key cache entries after project deletion:

  * `project:apikey:<publishableKey>`
  * `project:apikey:<secretKey>`
* Invalidated project cache:

  * `project:id:<projectId>`

## Problem

The public API authorization flow checks Redis before MongoDB. When a project was deleted, Redis cache entries remained available until TTL expiry, allowing previously cached API keys to continue authorizing requests.

## Result

Project deletion now immediately removes the associated Redis cache entries, ensuring deleted projects cannot continue authenticating through stale cached authorization data.
