### PR TITLE
Enabling PAT backend 

### DIFF
--- a/apps/dashboard-api/src/__tests__/routes.user.test.js
+++ b/apps/dashboard-api/src/__tests__/routes.user.test.js
@@ -42,6 +42,12 @@ jest.mock('../controllers/auth.controller', () => ({
     })),
 }));
 
+jest.mock('../controllers/pat.controller', () => ({
+    createPAT: jest.fn((_req, res) => res.json({ success: true })),
+    listPATs: jest.fn((_req, res) => res.json({ success: true })),
+    revokePAT: jest.fn((_req, res) => res.json({ success: true }))
+}));
+
 const express = require('express');
 const request = require('supertest');
 const userRouter = require('../routes/user');

--- a/apps/dashboard-api/src/controllers/pat.controller.js
+++ b/apps/dashboard-api/src/controllers/pat.controller.js
@@ -12,8 +12,11 @@ exports.createPAT = async (req, res, next) => {
         }
 
         // Lifetime & rotation - Default 30 days, force bounds to prevent permanent keys
-        const days = Number(ttlDays) || 30;
-        if (days <= 0 || days > 365) return next(new AppError(400, "Token TTL must be between 1 and 365 days."));
+        let days = 30;
+        if (ttlDays !== undefined && ttlDays !== null && ttlDays !== '') {
+            days = Number(ttlDays);
+        }
+        if (isNaN(days) || days <= 0 || days > 365) return next(new AppError(400, "Token TTL must be between 1 and 365 days."));
         
         const expiresAt = new Date();
         expiresAt.setDate(expiresAt.getDate() + days);
@@ -34,7 +37,7 @@ exports.createPAT = async (req, res, next) => {
         };
 
         const developer = await Developer.findByIdAndUpdate(
-            req.user.id,
+            req.user._id,
             { $push: { pats: newPat } },
             { new: true, runValidators: true }
         );
@@ -54,7 +57,7 @@ exports.createPAT = async (req, res, next) => {
 
 exports.listPATs = async (req, res, next) => {
     try {
-        const developer = await Developer.findById(req.user.id).select('pats');
+        const developer = await Developer.findById(req.user._id).select('pats');
         if (!developer) return next(new AppError(404, "Developer not found"));
 
         // only show masked suffix and metadata
@@ -81,7 +84,7 @@ exports.revokePAT = async (req, res, next) => {
     try {
         const { id } = req.params;
 
-        const developer = await Developer.findById(req.user.id).select('pats');
+        const developer = await Developer.findById(req.user._id).select('pats');
         if (!developer) return next(new AppError(404, "Developer not found"));
 
         const patToRevoke = developer.pats.find(p => p._id.toString() === id);
@@ -94,7 +97,11 @@ exports.revokePAT = async (req, res, next) => {
         await developer.save();
 
         // forcefully clear the Redis cache so ongoing sessions are immediately killed
-        await redis.del(`cli:pat:cache:${patToRevoke.tokenHash}`);
+        try {
+            await redis.del(`cli:pat:cache:${patToRevoke.tokenHash}`);
+        } catch (redisErr) {
+            console.error("Failed to clear PAT from Redis cache:", redisErr);
+        }
 
         return new ApiResponse({}, "Token revoked successfully").send(res, 200);
     } catch (err) {

--- a/apps/dashboard-api/src/controllers/pat.controller.js
+++ b/apps/dashboard-api/src/controllers/pat.controller.js
@@ -1,4 +1,4 @@
-const { Developer, generatePAT, redis, AppError, ApiResponse } = require('@urbackend/common');
+const { Developer, PAT, generatePAT, redis, AppError, ApiResponse } = require('@urbackend/common');
 
 exports.createPAT = async (req, res, next) => {
     try {
@@ -25,24 +25,15 @@ exports.createPAT = async (req, res, next) => {
         const environment = process.env.NODE_ENV === 'production' ? 'live' : 'test';
         const { rawToken, tokenHash, suffix } = generatePAT(environment);
 
-        const newPat = {
+        const newPat = await PAT.create({
+            developer: req.user._id,
             tokenHash,
             suffix,
             label,
             type,
             scopes,
-            expiresAt,
-            lastUsedAt: null,
-            lastUsedIp: null
-        };
-
-        const developer = await Developer.findByIdAndUpdate(
-            req.user._id,
-            { $push: { pats: newPat } },
-            { new: true, runValidators: true }
-        );
-
-        if (!developer) return next(new AppError(404, "Developer not found"));
+            expiresAt
+        });
 
         // Return raw token exactly once
         return new ApiResponse(
@@ -57,11 +48,10 @@ exports.createPAT = async (req, res, next) => {
 
 exports.listPATs = async (req, res, next) => {
     try {
-        const developer = await Developer.findById(req.user._id).select('pats');
-        if (!developer) return next(new AppError(404, "Developer not found"));
+        const pats = await PAT.find({ developer: req.user._id }).sort({ createdAt: -1 });
 
         // only show masked suffix and metadata
-        const safePats = developer.pats.map(pat => ({
+        const safePats = pats.map(pat => ({
             id: pat._id,
             suffix: pat.suffix,
             label: pat.label,
@@ -84,17 +74,11 @@ exports.revokePAT = async (req, res, next) => {
     try {
         const { id } = req.params;
 
-        const developer = await Developer.findById(req.user._id).select('pats');
-        if (!developer) return next(new AppError(404, "Developer not found"));
+        const patToRevoke = await PAT.findOneAndDelete({ _id: id, developer: req.user._id });
 
-        const patToRevoke = developer.pats.find(p => p._id.toString() === id);
         if (!patToRevoke) {
             return next(new AppError(404, "Token not found"));
         }
-
-        // Remove from DB
-        developer.pats = developer.pats.filter(p => p._id.toString() !== id);
-        await developer.save();
 
         // forcefully clear the Redis cache so ongoing sessions are immediately killed
         try {

--- a/apps/dashboard-api/src/controllers/pat.controller.js
+++ b/apps/dashboard-api/src/controllers/pat.controller.js
@@ -1,0 +1,104 @@
+const { Developer, generatePAT, redis, AppError, ApiResponse } = require('@urbackend/common');
+
+exports.createPAT = async (req, res, next) => {
+    try {
+        const { label, type = 'human', scopes, ttlDays } = req.body;
+
+        if (!label) return next(new AppError(400, "Token label is required."));
+        
+        // Force explicit selection, no automatic global access
+        if (!scopes || !Array.isArray(scopes) || scopes.length === 0) {
+            return next(new AppError(400, "At least one scope must be explicitly selected."));
+        }
+
+        // Lifetime & rotation - Default 30 days, force bounds to prevent permanent keys
+        const days = Number(ttlDays) || 30;
+        if (days <= 0 || days > 365) return next(new AppError(400, "Token TTL must be between 1 and 365 days."));
+        
+        const expiresAt = new Date();
+        expiresAt.setDate(expiresAt.getDate() + days);
+
+        // Generate PAT with base62 encoding
+        const environment = process.env.NODE_ENV === 'production' ? 'live' : 'test';
+        const { rawToken, tokenHash, suffix } = generatePAT(environment);
+
+        const newPat = {
+            tokenHash,
+            suffix,
+            label,
+            type,
+            scopes,
+            expiresAt,
+            lastUsedAt: null,
+            lastUsedIp: null
+        };
+
+        const developer = await Developer.findByIdAndUpdate(
+            req.user.id,
+            { $push: { pats: newPat } },
+            { new: true, runValidators: true }
+        );
+
+        if (!developer) return next(new AppError(404, "Developer not found"));
+
+        // Return raw token exactly once
+        return new ApiResponse(
+            { rawToken, pat: { suffix, label, type, scopes, expiresAt } },
+            "Token created successfully. Store this token now. You will not be able to see it again."
+        ).send(res, 201);
+    } catch (err) {
+        console.error(err);
+        return next(new AppError(500, "An error occurred while creating the token"));
+    }
+};
+
+exports.listPATs = async (req, res, next) => {
+    try {
+        const developer = await Developer.findById(req.user.id).select('pats');
+        if (!developer) return next(new AppError(404, "Developer not found"));
+
+        // only show masked suffix and metadata
+        const safePats = developer.pats.map(pat => ({
+            id: pat._id,
+            suffix: pat.suffix,
+            label: pat.label,
+            type: pat.type,
+            scopes: pat.scopes,
+            createdAt: pat.createdAt,
+            expiresAt: pat.expiresAt,
+            lastUsedAt: pat.lastUsedAt,
+            lastUsedIp: pat.lastUsedIp
+        }));
+
+        return new ApiResponse({ pats: safePats }).send(res, 200);
+    } catch (err) {
+        console.error(err);
+        return next(new AppError(500, "An error occurred while fetching tokens"));
+    }
+};
+
+exports.revokePAT = async (req, res, next) => {
+    try {
+        const { id } = req.params;
+
+        const developer = await Developer.findById(req.user.id).select('pats');
+        if (!developer) return next(new AppError(404, "Developer not found"));
+
+        const patToRevoke = developer.pats.find(p => p._id.toString() === id);
+        if (!patToRevoke) {
+            return next(new AppError(404, "Token not found"));
+        }
+
+        // Remove from DB
+        developer.pats = developer.pats.filter(p => p._id.toString() !== id);
+        await developer.save();
+
+        // forcefully clear the Redis cache so ongoing sessions are immediately killed
+        await redis.del(`cli:pat:cache:${patToRevoke.tokenHash}`);
+
+        return new ApiResponse({}, "Token revoked successfully").send(res, 200);
+    } catch (err) {
+        console.error(err);
+        return next(new AppError(500, "An error occurred while revoking the token"));
+    }
+};

--- a/apps/dashboard-api/src/middlewares/authenticateCLI.js
+++ b/apps/dashboard-api/src/middlewares/authenticateCLI.js
@@ -38,7 +38,7 @@ const authenticateCLI = async (req, res, next) => {
         let matchedPat;
 
         if (cachedContext) {
-            // Fix 1: Cache hit still constructs the context (and expiresAt will be checked below)
+            // Cache hit still constructs the context
             developer = { _id: cachedContext.developerId };
             matchedPat = {
                 _id: cachedContext.patId,
@@ -48,7 +48,7 @@ const authenticateCLI = async (req, res, next) => {
                 tokenHash: tokenHash
             };
         } else {
-            // Cache Miss: Query the new PAT collection
+            // query the new PAT collection
             matchedPat = await PAT.findOne({ tokenHash });
             if (!matchedPat) {
                 return next(new AppError(401, 'Unauthorized: Invalid or revoked token.'));

--- a/apps/dashboard-api/src/middlewares/authenticateCLI.js
+++ b/apps/dashboard-api/src/middlewares/authenticateCLI.js
@@ -1,0 +1,86 @@
+const { Developer, hashToken, redis, AppError } = require('@urbackend/common');
+const CACHE_TTL = process.env.CLI_PAT_CACHE_TTL || 300; // 5 minutes
+
+const authenticateCLI = async (req, res, next) => {
+    try {
+        // Accept only via Authorization Header
+        const authHeader = req.headers.authorization;
+        
+        if (req.query.token) {
+             // Aggressive rejection of query tokens to prevent accidental leak in server logs
+             return next(new AppError(400, 'Bad Request: Providing tokens in query parameters is strictly prohibited.'));
+        }
+
+        if (!authHeader || !authHeader.startsWith('Bearer ')) {
+            return next(new AppError(401, 'Unauthorized: Missing or invalid Bearer token.'));
+        }
+
+        const rawToken = authHeader.split(' ')[1];
+        if (!rawToken || !rawToken.startsWith('ubpat_')) {
+            return next(new AppError(401, 'Unauthorized: Invalid token format.'));
+        }
+
+        // Only checks the SHA-256 hash, raw token is never passed to DB
+        const tokenHash = hashToken(rawToken);
+        const cacheKey = `cli:pat:cache:${tokenHash}`;
+
+        // Distributed Caching
+        let developerId = await redis.get(cacheKey);
+        let developer;
+        let matchedPat;
+
+        if (developerId) {
+            developer = await Developer.findById(developerId);
+            if (!developer) {
+                await redis.del(cacheKey);
+                return next(new AppError(401, 'Unauthorized: Developer not found.'));
+            }
+            matchedPat = developer.pats.find(p => p.tokenHash === tokenHash);
+        } else {
+            developer = await Developer.findOne({ 'pats.tokenHash': tokenHash });
+            if (!developer) {
+                return next(new AppError(401, 'Unauthorized: Invalid or revoked token.'));
+            }
+            matchedPat = developer.pats.find(p => p.tokenHash === tokenHash);
+            
+            // Cache valid token to prevent DB hammering
+            await redis.setex(cacheKey, CACHE_TTL, developer._id.toString());
+        }
+
+        if (!matchedPat) {
+             return next(new AppError(401, 'Unauthorized: Invalid token state.'));
+        }
+
+        // Check expiry
+        if (matchedPat.expiresAt && new Date() > new Date(matchedPat.expiresAt)) {
+            await redis.del(cacheKey); 
+            return next(new AppError(401, 'Unauthorized: Token has expired.'));
+        }
+
+        // Fire async update (non-blocking) to log IP and Last Used time
+        const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+        
+        Developer.updateOne(
+            { _id: developer._id, 'pats._id': matchedPat._id },
+            { 
+                $set: { 
+                    'pats.$.lastUsedAt': new Date(),
+                    'pats.$.lastUsedIp': ip
+                }
+            }
+        ).catch(err => console.error("Failed to update PAT metadata:", err));
+
+        // Attach developer and PAT scopes for downstream controllers
+        req.user = { id: developer._id.toString() }; // Maintain compatibility with dashboard controllers
+        req.developer = developer;
+        req.cliScopes = matchedPat.scopes;
+        req.cliTokenType = matchedPat.type;
+        
+        next();
+    } catch (error) {
+        console.error("authenticateCLI error:", error);
+        return next(new AppError(500, 'Internal Server Error during CLI authentication.'));
+    }
+};
+
+module.exports = authenticateCLI;

--- a/apps/dashboard-api/src/middlewares/authenticateCLI.js
+++ b/apps/dashboard-api/src/middlewares/authenticateCLI.js
@@ -1,4 +1,4 @@
-const { Developer, hashToken, redis, AppError } = require('@urbackend/common');
+const { Developer, PAT, hashToken, redis, AppError } = require('@urbackend/common');
 const CACHE_TTL_ENV = parseInt(process.env.CLI_PAT_CACHE_TTL, 10);
 const CACHE_TTL = !isNaN(CACHE_TTL_ENV) ? CACHE_TTL_ENV : 300; // 5 minutes
 
@@ -26,9 +26,10 @@ const authenticateCLI = async (req, res, next) => {
         const cacheKey = `cli:pat:cache:${tokenHash}`;
 
         // Distributed Caching
-        let developerId = null;
+        let cachedContext = null;
         try {
-            developerId = await redis.get(cacheKey);
+            const rawCache = await redis.get(cacheKey);
+            if (rawCache) cachedContext = JSON.parse(rawCache);
         } catch (redisErr) {
             console.warn("Redis GET failed, falling back to DB:", redisErr);
         }
@@ -36,27 +37,41 @@ const authenticateCLI = async (req, res, next) => {
         let developer;
         let matchedPat;
 
-        if (developerId) {
-            developer = await Developer.findById(developerId);
-            if (!developer) {
-                try {
-                    await redis.del(cacheKey);
-                } catch (redisErr) {
-                    console.warn("Redis DEL failed:", redisErr);
-                }
-                return next(new AppError(401, 'Unauthorized: Developer not found.'));
-            }
-            matchedPat = developer.pats.find(p => p.tokenHash === tokenHash);
+        if (cachedContext) {
+            // Fix 1: Cache hit still constructs the context (and expiresAt will be checked below)
+            developer = { _id: cachedContext.developerId };
+            matchedPat = {
+                _id: cachedContext.patId,
+                scopes: cachedContext.scopes,
+                type: cachedContext.type,
+                expiresAt: cachedContext.expiresAt,
+                tokenHash: tokenHash
+            };
         } else {
-            developer = await Developer.findOne({ 'pats.tokenHash': tokenHash });
-            if (!developer) {
+            // Cache Miss: Query the new PAT collection
+            matchedPat = await PAT.findOne({ tokenHash });
+            if (!matchedPat) {
                 return next(new AppError(401, 'Unauthorized: Invalid or revoked token.'));
             }
-            matchedPat = developer.pats.find(p => p.tokenHash === tokenHash);
+            developer = { _id: matchedPat.developer.toString() };
             
-            // Cache valid token to prevent DB hammering
+            // Cache full context to prevent DB hammering
+            const contextToCache = {
+                developerId: developer._id,
+                patId: matchedPat._id.toString(),
+                scopes: matchedPat.scopes,
+                type: matchedPat.type,
+                expiresAt: matchedPat.expiresAt
+            };
             try {
-                await redis.setex(cacheKey, CACHE_TTL, developer._id.toString());
+                // Fix 2: Set Redis TTL = min(CACHE_TTL, remainingPATlifetime)
+                const remainingMs = new Date(matchedPat.expiresAt) - Date.now();
+                const remainingSec = Math.floor(remainingMs / 1000);
+                const redisTTL = Math.max(0, Math.min(CACHE_TTL, remainingSec));
+
+                if (redisTTL > 0) {
+                    await redis.setex(cacheKey, redisTTL, JSON.stringify(contextToCache));
+                }
             } catch (redisErr) {
                 console.warn("Redis SETEX failed:", redisErr);
             }
@@ -84,12 +99,12 @@ const authenticateCLI = async (req, res, next) => {
         // Fire async update (non-blocking) to log IP and Last Used time
         const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
         
-        Developer.updateOne(
-            { _id: developer._id, 'pats._id': matchedPat._id },
+        PAT.updateOne(
+            { _id: matchedPat._id },
             { 
                 $set: { 
-                    'pats.$.lastUsedAt': new Date(),
-                    'pats.$.lastUsedIp': ip
+                    lastUsedAt: new Date(),
+                    lastUsedIp: ip
                 }
             }
         ).catch(err => console.error("Failed to update PAT metadata:", err));

--- a/apps/dashboard-api/src/middlewares/authenticateCLI.js
+++ b/apps/dashboard-api/src/middlewares/authenticateCLI.js
@@ -1,5 +1,6 @@
 const { Developer, hashToken, redis, AppError } = require('@urbackend/common');
-const CACHE_TTL = process.env.CLI_PAT_CACHE_TTL || 300; // 5 minutes
+const CACHE_TTL_ENV = parseInt(process.env.CLI_PAT_CACHE_TTL, 10);
+const CACHE_TTL = !isNaN(CACHE_TTL_ENV) ? CACHE_TTL_ENV : 300; // 5 minutes
 
 const authenticateCLI = async (req, res, next) => {
     try {
@@ -25,14 +26,24 @@ const authenticateCLI = async (req, res, next) => {
         const cacheKey = `cli:pat:cache:${tokenHash}`;
 
         // Distributed Caching
-        let developerId = await redis.get(cacheKey);
+        let developerId = null;
+        try {
+            developerId = await redis.get(cacheKey);
+        } catch (redisErr) {
+            console.warn("Redis GET failed, falling back to DB:", redisErr);
+        }
+
         let developer;
         let matchedPat;
 
         if (developerId) {
             developer = await Developer.findById(developerId);
             if (!developer) {
-                await redis.del(cacheKey);
+                try {
+                    await redis.del(cacheKey);
+                } catch (redisErr) {
+                    console.warn("Redis DEL failed:", redisErr);
+                }
                 return next(new AppError(401, 'Unauthorized: Developer not found.'));
             }
             matchedPat = developer.pats.find(p => p.tokenHash === tokenHash);
@@ -44,16 +55,29 @@ const authenticateCLI = async (req, res, next) => {
             matchedPat = developer.pats.find(p => p.tokenHash === tokenHash);
             
             // Cache valid token to prevent DB hammering
-            await redis.setex(cacheKey, CACHE_TTL, developer._id.toString());
+            try {
+                await redis.setex(cacheKey, CACHE_TTL, developer._id.toString());
+            } catch (redisErr) {
+                console.warn("Redis SETEX failed:", redisErr);
+            }
         }
 
         if (!matchedPat) {
-             return next(new AppError(401, 'Unauthorized: Invalid token state.'));
+            try {
+                await redis.del(cacheKey);
+            } catch (redisErr) {
+                console.warn("Redis DEL failed:", redisErr);
+            }
+            return next(new AppError(401, 'Unauthorized: Invalid token state.'));
         }
 
         // Check expiry
         if (matchedPat.expiresAt && new Date() > new Date(matchedPat.expiresAt)) {
-            await redis.del(cacheKey); 
+            try {
+                await redis.del(cacheKey);
+            } catch (redisErr) {
+                console.warn("Redis DEL failed:", redisErr);
+            }
             return next(new AppError(401, 'Unauthorized: Token has expired.'));
         }
 

--- a/apps/dashboard-api/src/routes/user.js
+++ b/apps/dashboard-api/src/routes/user.js
@@ -2,8 +2,13 @@ const express = require('express');
 const router = express.Router();
 const authorization = require('../middlewares/authMiddleware');
 const { getMe, updateOnboarding } = require('../controllers/auth.controller');
+const { createPAT, listPATs, revokePAT } = require('../controllers/pat.controller');
 
 router.get('/me', authorization, getMe);
 router.patch('/onboarding', authorization, updateOnboarding);
+
+router.post('/pats', authorization, createPAT);
+router.get('/pats', authorization, listPATs);
+router.delete('/pats/:id', authorization, revokePAT);
 
 module.exports = router;

--- a/packages/common/src/index.js
+++ b/packages/common/src/index.js
@@ -15,6 +15,7 @@ const {
 
 // Models
 const Developer = require("./models/Developer");
+const PAT = require("./models/PAT");
 const Project = require("./models/Project");
 const MailTemplate = require("./models/MailTemplate");
 const Release = require("./models/Release");

--- a/packages/common/src/index.js
+++ b/packages/common/src/index.js
@@ -134,6 +134,7 @@ module.exports = {
   connectDB,
   redis,
   Developer,
+  PAT,
   Project,
   MailTemplate,
   Release,

--- a/packages/common/src/index.js
+++ b/packages/common/src/index.js
@@ -127,6 +127,7 @@ const {
   updateDeveloperOnboarding,
 } = require("./utils/onboarding");
 const { getProjectAccessQuery, getProjectRole } = require("./utils/projectAccess");
+const { generatePAT, hashToken, encodeBase62 } = require("./utils/token.utils");
 
 module.exports = {
   connectDB,
@@ -244,4 +245,7 @@ module.exports = {
   updateDeveloperOnboarding,
   getProjectAccessQuery,
   getProjectRole,
+  generatePAT,
+  hashToken,
+  encodeBase62,
 };

--- a/packages/common/src/models/Developer.js
+++ b/packages/common/src/models/Developer.js
@@ -44,17 +44,6 @@ const onboardingSchema = new mongoose.Schema({
     }
 }, { _id: false });
 
-const patSchema = new mongoose.Schema({
-    tokenHash: { type: String, required: true },
-    suffix: { type: String, required: true },
-    label: { type: String, required: true },
-    type: { type: String, enum: ['human', 'agent'], required: true },
-    scopes: { type: [String], required: true },
-    lastUsedAt: { type: Date, default: null },
-    lastUsedIp: { type: String, default: null },
-    expiresAt: { type: Date, required: true },
-    createdAt: { type: Date, default: Date.now }
-});
 
 const developerSchema = new mongoose.Schema({
     email: {
@@ -117,13 +106,7 @@ const developerSchema = new mongoose.Schema({
     onboarding: {
         type: onboardingSchema,
         default: () => ({})
-    },
-    pats: {
-        type: [patSchema],
-        default: []
     }
 }, { timestamps: true });
-
-developerSchema.index({ 'pats.tokenHash': 1 });
 
 module.exports = mongoose.model('Developer', developerSchema);

--- a/packages/common/src/models/Developer.js
+++ b/packages/common/src/models/Developer.js
@@ -124,4 +124,6 @@ const developerSchema = new mongoose.Schema({
     }
 }, { timestamps: true });
 
+developerSchema.index({ 'pats.tokenHash': 1 });
+
 module.exports = mongoose.model('Developer', developerSchema);

--- a/packages/common/src/models/Developer.js
+++ b/packages/common/src/models/Developer.js
@@ -44,6 +44,18 @@ const onboardingSchema = new mongoose.Schema({
     }
 }, { _id: false });
 
+const patSchema = new mongoose.Schema({
+    tokenHash: { type: String, required: true },
+    suffix: { type: String, required: true },
+    label: { type: String, required: true },
+    type: { type: String, enum: ['human', 'agent'], required: true },
+    scopes: { type: [String], required: true },
+    lastUsedAt: { type: Date, default: null },
+    lastUsedIp: { type: String, default: null },
+    expiresAt: { type: Date, required: true },
+    createdAt: { type: Date, default: Date.now }
+});
+
 const developerSchema = new mongoose.Schema({
     email: {
         type: String,
@@ -105,6 +117,10 @@ const developerSchema = new mongoose.Schema({
     onboarding: {
         type: onboardingSchema,
         default: () => ({})
+    },
+    pats: {
+        type: [patSchema],
+        default: []
     }
 }, { timestamps: true });
 

--- a/packages/common/src/models/PAT.js
+++ b/packages/common/src/models/PAT.js
@@ -12,7 +12,7 @@ const patSchema = new mongoose.Schema({
     label: { type: String, required: true },
     type: { type: String, enum: ['human', 'agent'], default: 'human' },
     scopes: [{ type: String }],
-    expiresAt: { type: Date, required: true, index: true }, // Indexed for TTL and queries
+    expiresAt: { type: Date, required: true }, // TTL index handles indexing
     lastUsedAt: { type: Date, default: null },
     lastUsedIp: { type: String, default: null },
     createdAt: { type: Date, default: Date.now }

--- a/packages/common/src/models/PAT.js
+++ b/packages/common/src/models/PAT.js
@@ -18,7 +18,7 @@ const patSchema = new mongoose.Schema({
     createdAt: { type: Date, default: Date.now }
 });
 
-// Native MongoDB TTL index - auto-deletes expired PATs at exactly expiresAt time
+// auto-deletes expired PATs at exactly expiresAt time
 patSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
 module.exports = mongoose.model('PAT', patSchema);

--- a/packages/common/src/models/PAT.js
+++ b/packages/common/src/models/PAT.js
@@ -1,0 +1,24 @@
+const mongoose = require('mongoose');
+
+const patSchema = new mongoose.Schema({
+    developer: { 
+        type: mongoose.Schema.Types.ObjectId, 
+        ref: 'Developer', 
+        required: true, 
+        index: true 
+    },
+    tokenHash: { type: String, required: true, unique: true, select: false },
+    suffix: { type: String, required: true },
+    label: { type: String, required: true },
+    type: { type: String, enum: ['human', 'agent'], default: 'human' },
+    scopes: [{ type: String }],
+    expiresAt: { type: Date, required: true, index: true }, // Indexed for TTL and queries
+    lastUsedAt: { type: Date, default: null },
+    lastUsedIp: { type: String, default: null },
+    createdAt: { type: Date, default: Date.now }
+});
+
+// Native MongoDB TTL index - auto-deletes expired PATs at exactly expiresAt time
+patSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+module.exports = mongoose.model('PAT', patSchema);

--- a/packages/common/src/utils/token.utils.js
+++ b/packages/common/src/utils/token.utils.js
@@ -1,0 +1,71 @@
+const crypto = require('crypto');
+
+// Standard Base62 character set
+const BASE62_CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+/**
+ * For future Developer Reference 
+ * Encodes a Buffer to a Base62 string
+ * @param {Buffer} buffer
+ * @returns {string} Base62 string
+ */
+
+function encodeBase62(buffer) {
+    let value = BigInt('0x' + buffer.toString('hex'));
+    let result = '';
+    const base = BigInt(62);
+    
+    while (value > 0n) {
+        result = BASE62_CHARS[Number(value % base)] + result;
+        value = value / base;
+    }
+    
+    // Handle leading zeros
+    for (let i = 0; i < buffer.length; i++) {
+        if (buffer[i] !== 0) break;
+        result = BASE62_CHARS[0] + result;
+    }
+    
+    return result || BASE62_CHARS[0];
+}
+
+/**
+ * Generates a Personal Access Token
+ * @param {string} environment - 'live' or 'test'
+ * @returns {Object} { rawToken, tokenHash, suffix }
+ */
+
+function generatePAT(environment = 'live') {
+    // Generate 32 bytes of CSPRNG entropy (256 bits)
+    const rawBytes = crypto.randomBytes(32);
+    
+    // Encode to base62 to avoid URL/shell character issues
+    const tokenPart = encodeBase62(rawBytes);
+    
+    // Prefix the token for easy environment identification and secret scanning
+    const rawToken = `ubpat_${environment}_${tokenPart}`;
+    
+    // SHA-256 hash for secure server-side storage
+    const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
+    
+    // Extract the last 4 characters for UI masking
+    const suffix = tokenPart.slice(-4);
+    
+    return { rawToken, tokenHash, suffix };
+}
+
+/**
+ * Hashes an existing token for verification
+ * @param {string} rawToken 
+ * @returns {string} SHA-256 hash
+ */
+
+function hashToken(rawToken) {
+    return crypto.createHash('sha256').update(rawToken).digest('hex');
+}
+
+module.exports = {
+    generatePAT,
+    hashToken,
+    encodeBase62
+};


### PR DESCRIPTION
## 🚀 Pull Request Description

I had enabled PAT for project, Now CLI/AI Agents can easily authenticate against Dashboard API.
Added the PAT generator which adds prefix to generated PAT.
Also included PAT schema in developer model.
Added strict PAT validation middleware with Redis caching

## 🛠️ Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement (Frontend only)
- [ ] ⚙️ Refactor / Chore

## 🧪 Testing & Validation
### Backend Verification:
- [x] I have run `npm test` in the `backend/` directory and all tests passed.
- [ ] I have verified the API endpoints using Postman/Thunder Client.
- [x] New unit tests have been added (if applicable).

### Frontend Verification:
- [x] I have run `npm run lint` in the `frontend/` directory.
- [ ] Verified the UI changes on different screen sizes (Responsive).
- [x] Checked for any console errors in the browser dev tools.

## ✅ Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or errors.
- [ ] I have updated the documentation (README/Docs) accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added personal access token (PAT) API endpoints to create, list, and revoke tokens.
  * Tokens support labels, scopes, bounded TTL (default 30 days, 1–365 days), and return masked token details plus usage/expiry metadata.
  * Enabled CLI authentication using Bearer PATs with a required prefix, including cache-backed validation to reduce repeated lookups.
* **Tests**
  * Updated route tests to mock PAT controller create/list/revoke behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->