### PR TITLE
feat: disable public signup toggle and react sdk prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ const post = await client.db.insert('posts', {
 | `403 Insert denied` (ownerField `_id`) | `_id` is not a valid owner field for inserts | Change ownerField to `userId` or similar |
 | `403 Owner field immutable` | Trying to change the owner field on update | Remove the owner field from the PATCH/PUT body |
 
+## Public Signup
+
+By default, new users can sign up using email/password or social providers. You can disable public signups from the **Authentication** page in the dashboard under the **Allow Public Signups** toggle. When disabled, the API blocks new registrations, allowing only existing users to log in.
+
 ---
 
 ## Social Auth

--- a/apps/dashboard-api/src/__tests__/routes.projects.storage.test.js
+++ b/apps/dashboard-api/src/__tests__/routes.projects.storage.test.js
@@ -68,6 +68,7 @@ jest.mock('../controllers/project.controller', () => {
     analytics: jest.fn(ok),
     updateAllowedDomains: jest.fn(ok),
     toggleAuth: jest.fn(ok),
+    togglePublicSignup: jest.fn(ok),
     updateAuthProviders: jest.fn(ok),
     updateCollectionRls: jest.fn(ok),
     listMailTemplates: jest.fn(ok),

--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -2553,6 +2553,36 @@ module.exports.toggleAuth = async (req, res) => {
   }
 };
 
+module.exports.togglePublicSignup = async (req, res) => {
+  try {
+    const { projectId } = req.params;
+    const { enable } = req.body;
+
+    const project = await Project.findOne({
+      _id: projectId,
+      ...getProjectAccessQuery(req.user._id),
+    });
+    if (!project) return res.status(404).json({ error: "Project not found" });
+
+    project.allowPublicSignup = !!enable;
+    await project.save();
+
+    await deleteProjectById(projectId);
+    await deleteProjectByApiKeyCache(project.publishableKey);
+    await deleteProjectByApiKeyCache(project.secretKey);
+
+    const projectObj = sanitizeProjectResponse(project.toObject());
+
+    res.json({
+      message: `Public signup ${project.allowPublicSignup ? "enabled" : "disabled"} successfully`,
+      allowPublicSignup: project.allowPublicSignup,
+      project: projectObj,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
 module.exports.updateAuthProviders = async (req, res) => {
   try {
     const { projectId } = req.params;

--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -2553,18 +2553,22 @@ module.exports.toggleAuth = async (req, res) => {
   }
 };
 
-module.exports.togglePublicSignup = async (req, res) => {
+module.exports.togglePublicSignup = async (req, res, next) => {
   try {
     const { projectId } = req.params;
     const { enable } = req.body;
+
+    if (typeof enable !== "boolean") {
+      return next(new AppError(400, "enable parameter must be a boolean"));
+    }
 
     const project = await Project.findOne({
       _id: projectId,
       ...getProjectAccessQuery(req.user._id),
     });
-    if (!project) return res.status(404).json({ error: "Project not found" });
+    if (!project) return next(new AppError(404, "Project not found"));
 
-    project.allowPublicSignup = !!enable;
+    project.allowPublicSignup = enable;
     await project.save();
 
     await deleteProjectById(projectId);
@@ -2574,12 +2578,15 @@ module.exports.togglePublicSignup = async (req, res) => {
     const projectObj = sanitizeProjectResponse(project.toObject());
 
     res.json({
-      message: `Public signup ${project.allowPublicSignup ? "enabled" : "disabled"} successfully`,
-      allowPublicSignup: project.allowPublicSignup,
-      project: projectObj,
+      success: true,
+      data: {
+        allowPublicSignup: project.allowPublicSignup,
+        project: projectObj,
+      },
+      message: `Public signup ${project.allowPublicSignup ? "enabled" : "disabled"} successfully`
     });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    next(err);
   }
 };
 

--- a/apps/dashboard-api/src/routes/projects.js
+++ b/apps/dashboard-api/src/routes/projects.js
@@ -31,6 +31,7 @@ const {
     analytics,
     updateAllowedDomains,
     toggleAuth,
+    togglePublicSignup,
     updateAuthProviders,
     updateCollectionRls,
     listMailTemplates,
@@ -138,6 +139,7 @@ router.get('/:projectId/analytics', authMiddleware, authorizeProject(), analytic
 
 // PATCH REQ FOR TOGGLE AUTH
 router.patch('/:projectId/auth/toggle', authMiddleware, authorizeProject('admin'), verifyEmail, toggleAuth);
+router.patch('/:projectId/auth/public-signup', authMiddleware, authorizeProject('admin'), verifyEmail, togglePublicSignup);
 
 // PATCH REQ FOR SOCIAL AUTH PROVIDERS
 router.patch('/:projectId/auth/providers', authMiddleware, authorizeProject('admin'), planEnforcement.attachDeveloper, verifyEmail, planEnforcement.checkByokGate, updateAuthProviders);

--- a/apps/public-api/src/controllers/userAuth.controller.js
+++ b/apps/public-api/src/controllers/userAuth.controller.js
@@ -618,9 +618,7 @@ const findOrCreateSocialUser = async ({ project, usersColConfig, Model, provider
     }
 
     if (project.allowPublicSignup === false) {
-        const err = new Error("Public signup is disabled for this project. Only existing users can log in.");
-        err.statusCode = 403;
-        throw err;
+        throw new AppError(403, "Public signup is disabled for this project. Only existing users can log in.");
     }
 
     const newUserPayload = await buildSocialAuthUserPayload(usersColConfig, profile);

--- a/apps/public-api/src/controllers/userAuth.controller.js
+++ b/apps/public-api/src/controllers/userAuth.controller.js
@@ -617,6 +617,12 @@ const findOrCreateSocialUser = async ({ project, usersColConfig, Model, provider
         return { user, isNewUser: false, linkedByEmail: true };
     }
 
+    if (project.allowPublicSignup === false) {
+        const err = new Error("Public signup is disabled for this project. Only existing users can log in.");
+        err.statusCode = 403;
+        throw err;
+    }
+
     const newUserPayload = await buildSocialAuthUserPayload(usersColConfig, profile);
     newUserPayload[providerIdField] = profile.providerUserId;
     newUserPayload.authProviders = [providerName];
@@ -987,6 +993,10 @@ module.exports.exchangeSocialRefreshToken = async (req, res, next) => {
 module.exports.signup = async (req, res, next) => {
     try {
         const project = req.project;
+
+        if (project.allowPublicSignup === false) {
+            return next(new AppError(403, "Public signup is disabled for this project"));
+        }
 
         const { email, password, username, ...otherData } = userSignupSchema.parse(req.body);
         const normalizedEmail = email.toLowerCase().trim();

--- a/apps/web-dashboard/src/pages/Auth.jsx
+++ b/apps/web-dashboard/src/pages/Auth.jsx
@@ -34,6 +34,7 @@ export default function Auth() {
     const [searchTerm, setSearchTerm] = useState('');
     const [project, setProject] = useState(null);
     const [isEnabling, setIsEnabling] = useState(false);
+    const [isTogglingSignup, setIsTogglingSignup] = useState(false);
     const [isSavingProviders, setIsSavingProviders] = useState(false);
     const [isSocialAuthModalOpen, setIsSocialAuthModalOpen] = useState(false);
     const [isAddModalOpen, setIsAddModalOpen] = useState(false);
@@ -59,6 +60,13 @@ export default function Auth() {
     const siteUrl = project?.siteUrl || '';
     const githubCallbackUrl = `${PUBLIC_API_URL}/api/userAuth/social/github/callback`;
     const googleCallbackUrl = `${PUBLIC_API_URL}/api/userAuth/social/google/callback`;
+
+    const myMember = project?.members?.find(m => {
+        const memberId = typeof m.user === 'object' ? m.user?._id : m.user;
+        return memberId?.toString() === user?._id?.toString() || m.email === user?.email;
+    });
+    const myRole = project?.owner?.toString() === user?._id?.toString() ? 'owner' : (myMember?.role || 'viewer');
+    const isViewer = myRole === 'viewer';
 
     // Flow Logic
     const usersCollection = project?.collections?.find(c => c.name === 'users');
@@ -149,12 +157,16 @@ export default function Auth() {
     };
 
     const handleTogglePublicSignup = async (enable) => {
+        if (isTogglingSignup || isViewer) return;
+        setIsTogglingSignup(true);
         try {
             const res = await api.patch(`/api/projects/${projectId}/auth/public-signup`, { enable });
             setProject(res.data.project);
             toast.success(`Public signup ${enable ? 'enabled' : 'disabled'}`);
         } catch (err) {
             toast.error(err.response?.data?.message || 'Failed to toggle public signup');
+        } finally {
+            setIsTogglingSignup(false);
         }
     };
 
@@ -219,13 +231,6 @@ export default function Auth() {
     const filteredUsers = users.filter(u => u.email?.toLowerCase().includes(searchTerm.toLowerCase()));
 
     if (loading) return <div className="container spinner"></div>;
-
-    const myMember = project?.members?.find(m => {
-        const memberId = typeof m.user === 'object' ? m.user?._id : m.user;
-        return memberId?.toString() === user?._id?.toString() || m.email === user?.email;
-    });
-    const myRole = project?.owner?.toString() === user?._id?.toString() ? 'owner' : (myMember?.role || 'viewer');
-    const isViewer = myRole === 'viewer';
 
     return (
         <div className="container" style={{ maxWidth: '1200px', margin: '0 auto', paddingBottom: '4rem' }}>
@@ -379,8 +384,9 @@ export default function Auth() {
                                     type="checkbox" 
                                     checked={project?.allowPublicSignup !== false} 
                                     onChange={(e) => handleTogglePublicSignup(e.target.checked)} 
+                                    disabled={isTogglingSignup || isViewer}
                                 />
-                                <span className="slider round"></span>
+                                <span className={`slider round ${(isTogglingSignup || isViewer) ? 'disabled' : ''}`}></span>
                             </label>
                         </div>
 

--- a/apps/web-dashboard/src/pages/Auth.jsx
+++ b/apps/web-dashboard/src/pages/Auth.jsx
@@ -148,6 +148,16 @@ export default function Auth() {
         finally { setIsSavingProviders(false); }
     };
 
+    const handleTogglePublicSignup = async (enable) => {
+        try {
+            const res = await api.patch(`/api/projects/${projectId}/auth/public-signup`, { enable });
+            setProject(res.data.project);
+            toast.success(`Public signup ${enable ? 'enabled' : 'disabled'}`);
+        } catch (err) {
+            toast.error(err.response?.data?.message || 'Failed to toggle public signup');
+        }
+    };
+
     const goToUsersSchemaPreset = () => {
         navigate(`/project/${projectId}/create-collection?name=users&preset=auth-users`);
     };
@@ -356,6 +366,24 @@ export default function Auth() {
 
                     <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
                         <SectionHeader title="Settings" />
+                        
+                        <div className="glass-card" style={{ padding: '1.25rem', borderRadius: '12px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                            <div>
+                                <h4 style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: '4px' }}>Allow Public Signups</h4>
+                                <p style={{ fontSize: '0.7rem', color: 'var(--color-text-muted)' }}>
+                                    When disabled, new users cannot sign up via API or OAuth. Only existing users can log in.
+                                </p>
+                            </div>
+                            <label className="switch">
+                                <input 
+                                    type="checkbox" 
+                                    checked={project?.allowPublicSignup !== false} 
+                                    onChange={(e) => handleTogglePublicSignup(e.target.checked)} 
+                                />
+                                <span className="slider round"></span>
+                            </label>
+                        </div>
+
                         <SocialAuthConfig 
                             authProviders={authProviders}
                             onOpenModal={() => setIsSocialAuthModalOpen(true)}

--- a/mintlify/docs/guides/authentication.mdx
+++ b/mintlify/docs/guides/authentication.mdx
@@ -9,6 +9,15 @@ All auth endpoints require your publishable key (`pk_live_...`) in the `x-api-ke
 
 **Base URL:** `https://api.ub.bitbros.in`
 
+## Disabling Public Signups
+
+By default, any user can create an account. To block new registrations:
+1. Navigate to your project dashboard.
+2. Go to the **Authentication** page.
+3. Turn off the **Allow Public Signups** toggle.
+
+Once disabled, new signups will receive a `403 Forbidden` error, but existing users can still log in.
+
 ## The `users` collection contract
 
 Before using authentication, create a collection named `users` in your project. It must include at least these two fields:

--- a/mintlify/docs/react-sdk/ur-auth.mdx
+++ b/mintlify/docs/react-sdk/ur-auth.mdx
@@ -35,6 +35,7 @@ export default function LoginPage() {
 | `colors` | `Partial<AuthColors>` | `undefined` | Overrides for auth widget theme colors. |
 | `branding` | `AuthBranding` | `undefined` | Branding/white-label configuration (logo, app name, subtitle, brand color). |
 | `labels` | `Partial<AuthLabels>` | `undefined` | Text/copy overrides for tabs, titles, buttons, and footer prompts. |
+| `hideSignup` | `boolean` | `false` | Hides the sign up tab and sign up footer toggle when true. |
 | `onSuccess` | `() => void` | `undefined` | Called after successful sign-in or sign-up flow. |
 
 > All customization props are optional. If omitted, `<UrAuth>` falls back to the same default behavior/UI style as v0.1.x.

--- a/packages/common/src/models/Project.js
+++ b/packages/common/src/models/Project.js
@@ -107,6 +107,7 @@ const projectSchema = new mongoose.Schema(
       required: true,
     },
     isAuthEnabled: { type: Boolean, default: false },
+    allowPublicSignup: { type: Boolean, default: true },
     siteUrl: { type: String, default: "" },
     /**
      * Managed OAuth providers for project user authentication.

--- a/sdks/urbackend-react/README.md
+++ b/sdks/urbackend-react/README.md
@@ -41,7 +41,11 @@ import { UrAuth, GuestRoute } from '@urbackend/react';
 export default function LoginPage() {
   return (
     <GuestRoute fallback={<div>Loading...</div>} onRedirect={() => window.location.href = '/dashboard'}>
-      <UrAuth providers={['google', 'github']} theme="light" />
+      <UrAuth 
+        providers={['google', 'github']} 
+        theme="light" 
+        hideSignup={false} // Set to true to hide the signup tab
+      />
     </GuestRoute>
   );
 }

--- a/sdks/urbackend-react/src/components/UrAuth.tsx
+++ b/sdks/urbackend-react/src/components/UrAuth.tsx
@@ -208,7 +208,6 @@ export const UrAuth: React.FC<UrAuthProps> = ({
       : mode === 'forgot'
         ? text.forgotTitle
         : text.resetTitle);
-  const showSwitcher = hasPasswordAuth;
 
   useEffect(() => {
     if (error) {
@@ -655,7 +654,7 @@ export const UrAuth: React.FC<UrAuthProps> = ({
         {(mode === 'signin' || mode === 'signup') && renderSocialButtons()}
       </div>
 
-      {hasPasswordAuth && (
+      {hasPasswordAuth && (!hideSignup || mode !== 'signin') && (
         <div style={styles.footer}>
           {footerPrompt}
           <button 

--- a/sdks/urbackend-react/src/components/UrAuth.tsx
+++ b/sdks/urbackend-react/src/components/UrAuth.tsx
@@ -80,6 +80,7 @@ export interface UrAuthProps {
   branding?: AuthBranding;
   labels?: Partial<AuthLabels>;
   onSuccess?: () => void;
+  hideSignup?: boolean;
 }
 
 const defaultLabels: AuthLabels = {
@@ -153,10 +154,11 @@ export const UrAuth: React.FC<UrAuthProps> = ({
   colors,
   branding,
   labels,
-  onSuccess
+  onSuccess,
+  hideSignup = false
 }) => {
   const { login, signUp, socialLogin, requestPasswordReset, resetPassword, isLoading, error, clearError } = useAuth();
-  const [mode, setMode] = useState<'signin' | 'signup' | 'forgot' | 'reset'>('signin');
+  const [mode, setMode] = useState<'signin' | 'signup' | 'forgot' | 'reset'>(hideSignup ? 'signin' : 'signin');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [otp, setOtp] = useState('');
@@ -194,6 +196,8 @@ export const UrAuth: React.FC<UrAuthProps> = ({
 
   const hasPasswordAuth = isEmailPasswordEnabled;
   const hasSocialAuth = isGoogleEnabled || isGithubEnabled;
+
+  const showSwitcher = hasPasswordAuth && !hideSignup;
   const brandName = branding?.brandName || branding?.appName || branding?.title || 'urBackend';
   const headerTitle = branding?.title || brandName;
   const brandingLogo = branding?.logo ?? branding?.logoUrl;


### PR DESCRIPTION
1. Disable Public Signup Toggle
Backend: Added the allowPublicSignup field to the project schema. The /api/projects/:projectId/auth/public-signup endpoint now allows toggling this setting.
Enforcement: Updated the signup and OAuth callback methods in userAuth.controller.js to immediately block new users with a 403 error if allowPublicSignup is false. Existing users can still log in fine.
Dashboard UI: Added a beautiful toggle under the "Settings" section on the Authentication page (Auth.jsx).

2. React SDK hideSignup Prop
Added an optional hideSignup?: boolean prop to <UrAuth /> inside @urbackend/react.
When set to true, the "Sign Up" tab on the authentication widget is completely hidden, and it defaults to the signin mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project administrators can now enable or disable public signups from project settings via a new toggle control
  * New user registrations via email and social authentication are blocked when public signups are disabled for the project
  * Authentication SDK now includes an option to hide the signup interface in authentication flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->