### PR TITLE
fix: make daily export limit check atomic to prevent concurrent requests bypassing quota

### DIFF
--- a/apps/dashboard-api/src/controllers/dbExport.controller.js
+++ b/apps/dashboard-api/src/controllers/dbExport.controller.js
@@ -46,14 +46,34 @@ module.exports.dbExportHandler = async (req, res, next) => {
         const today = new Date().toISOString().split('T')[0];
         const key = `project:${projectId}:export_limit:${today}`;
 
-        const currentCount = await redis.get(key);
-        if (currentCount && Number(currentCount) >= maxExports) {
-            return next(new AppError(429, `Daily export limit reached (${maxExports}/${maxExports}). Please try again tomorrow.`));
+        // Atomic check-and-increment: use Lua script to prevent TOCTOU race where
+        // two concurrent requests both read the current count, both pass the limit
+        // check, and both increment, exceeding the daily quota. The script ensures
+        // only one request at a time sees a sub-limit count.
+        const luaScript = `
+            local current = redis.call('GET', KEYS[1])
+            current = current and tonumber(current) or 0
+            if current >= tonumber(ARGV[1]) then
+                return {0, current}
+            end
+            local newCount = redis.call('INCR', KEYS[1])
+            if newCount == 1 then
+                redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+            end
+            return {1, newCount}
+        `;
+
+        let result;
+        try {
+            result = await redis.eval(luaScript, 1, key, maxExports, 86400);
+        } catch (err) {
+            console.error("[Dashboard API] Redis Lua script error:", err);
+            return next(new AppError(500, "Failed to check export quota."));
         }
 
-        const newCount = await redis.incr(key);
-        if (newCount === 1) {
-            await redis.expire(key, 86400); // Set expiry to 24 hours
+        const [allowed, newCount] = result;
+        if (!allowed) {
+            return next(new AppError(429, `Daily export limit reached (${maxExports}/${maxExports}). Please try again tomorrow.`));
         }
 
         await exportQueue.add('export-database', { projectId, collectionName, userId, email });


### PR DESCRIPTION
## Problem

The export quota check used a non-atomic pattern: get the current count from Redis, check if it's at the limit, then increment. Two concurrent requests could:

1. Both read `currentCount = 0`
2. Both pass the limit check `0 < maxExports`
3. Both call `redis.incr(key)`, resulting in a count of 2
4. Both succeed despite a daily quota of 1 (or 5 for pro)

Steps to reproduce (from issue):
1. Set `maxExports = 1`
2. Send two simultaneous POST requests to the export endpoint
3. Both requests succeed with usage counts 1/1 and 2/1
4. The quota is bypassed

## Fix

Use a Lua script to atomically check and increment in a single Redis transaction. The script is executed on the server side, ensuring no interleaving between the check and increment:

```lua
if current >= maxExports then
    return rejected
else
    increment and return new count
end
```

Concurrent requests now correctly queue at the limit and are rejected once quota is reached.

Closes #255