### PR TITLE
feat(dashboard): add info popovers with docs links across all settings

### DIFF
--- a/apps/web-dashboard/src/components/PATManager.jsx
+++ b/apps/web-dashboard/src/components/PATManager.jsx
@@ -3,6 +3,7 @@ import api from '../utils/api';
 import toast from 'react-hot-toast';
 import { Key, Trash2, Plus, Copy, CheckCircle, AlertTriangle } from 'lucide-react';
 import ConfirmationModal from '../pages/ConfirmationModal';
+import SettingInfoTooltip from './Settings/SettingInfoTooltip';
 
 const formatDate = (dateString) => {
     if (!dateString) return 'Never';
@@ -154,7 +155,14 @@ export default function PATManager() {
                         <Key size={20} />
                     </div>
                     <div>
-                        <h3 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '2px' }}>Personal Access Tokens</h3>
+                        <h3 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '2px', display: 'flex', alignItems: 'center' }}>
+                            Personal Access Tokens
+                            <SettingInfoTooltip
+                                title="Personal Access Tokens (PAT)"
+                                description="Long-lived authentication tokens for the urBackend CLI (@urbackend/cli). Each token is prefixed with ubpat_ and is shown only once on creation — store it securely. You can set a TTL of 7, 30, 90, or 365 days. Use 'ub login' in your terminal with a PAT to authenticate the CLI."
+                                docsUrl="https://docs.ub.bitbros.in/cli/overview"
+                            />
+                        </h3>
                         <p style={{ fontSize: '0.85rem', color: 'var(--color-text-muted)' }}>Generate tokens to securely authenticate with the urBackend CLI.</p>
                     </div>
                 </div>

--- a/apps/web-dashboard/src/components/Settings/AllowedDomainsForm.jsx
+++ b/apps/web-dashboard/src/components/Settings/AllowedDomainsForm.jsx
@@ -44,7 +44,17 @@ export default function AllowedDomainsForm({ project, projectId, onProjectUpdate
     const removeDomain = (d) => handleUpdate(domains.filter(x => x !== d));
 
     return (
-        <SettingsCard title="Allowed Domains (CORS)" icon={Globe} iconColor="#6366f1" accentColor="#6366f1">
+        <SettingsCard
+            title="Allowed Domains (CORS)"
+            icon={Globe}
+            iconColor="#6366f1"
+            accentColor="#6366f1"
+            info={{
+                title: 'Allowed Domains (CORS)',
+                description: "Restricts which browser origins are permitted to make requests using your Publishable API Key (pk_live_...). Add your frontend URL like https://myapp.com. Use * to allow all origins (not recommended for production). If this list is empty, pk_live requests from browsers will be blocked.",
+                docsUrl: 'https://docs.ub.bitbros.in/concepts/api-keys'
+            }}
+        >
             <p style={{ fontSize: '0.75rem', color: 'var(--color-text-muted)', marginBottom: '0.75rem', lineHeight: 1.5 }}>
                 Restrict which websites can send requests using your <strong>Publishable API Key</strong>.{' '}
                 Use <code>*</code> to allow all, or specify like <code>https://example.com</code>.

--- a/apps/web-dashboard/src/components/Settings/DatabaseConfigForm.jsx
+++ b/apps/web-dashboard/src/components/Settings/DatabaseConfigForm.jsx
@@ -91,7 +91,17 @@ export default function DatabaseConfigForm({ project, projectId, onProjectUpdate
     };
 
     return (
-        <SettingsCard title="Database (MongoDB)" icon={Database} iconColor="var(--color-primary)" accentColor="var(--color-primary)">
+        <SettingsCard
+            title="Database (MongoDB)"
+            icon={Database}
+            iconColor="var(--color-primary)"
+            accentColor="var(--color-primary)"
+            info={{
+                title: 'Database — Bring Your Own Database (BYOD)',
+                description: "Connect your own MongoDB Atlas cluster (or any MongoDB-compatible URI) as the data store for this project. Both the Dashboard API and Public API server IPs must be whitelisted in Atlas. Once connected, all collection data is stored in your own cluster — urBackend becomes a headless layer. The connection URI is encrypted at rest.",
+                docsUrl: 'https://docs.ub.bitbros.in/guides/database#connect-your-own-mongodb-byod'
+            }}
+        >
             {showRemoveModal && (
                 <ConfirmationModal
                     open={showRemoveModal}

--- a/apps/web-dashboard/src/components/Settings/IntegrationsSettings.jsx
+++ b/apps/web-dashboard/src/components/Settings/IntegrationsSettings.jsx
@@ -11,6 +11,7 @@ import { inputStyle } from '../../utils/styles';
 import DatabaseConfigForm from './DatabaseConfigForm';
 import StorageConfigForm from './StorageConfigForm';
 import MailTemplatesForm from './MailTemplatesForm';
+import SettingInfoTooltip from './SettingInfoTooltip';
 
 /* ─── SVG Brand Icons ─── */
 const Icons = {
@@ -251,7 +252,14 @@ export default function IntegrationsSettings({
             <div>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
                     <div>
-                        <h3 style={{ fontSize: '1rem', fontWeight: 600, margin: 0 }}>OAuth2 Providers</h3>
+                        <h3 style={{ fontSize: '1rem', fontWeight: 600, margin: 0, display: 'flex', alignItems: 'center' }}>
+                            OAuth2 Providers
+                            <SettingInfoTooltip
+                                title="OAuth2 Social Auth Providers"
+                                description="Enable GitHub or Google social login for your application's end-users. You need to register an OAuth app on each provider's developer console, then paste the Client ID and Client Secret here. The Callback URL is auto-generated and read-only — copy it into the provider's app settings. Credentials are encrypted at rest."
+                                docsUrl="https://docs.ub.bitbros.in/guides/social-auth"
+                            />
+                        </h3>
                         <p style={{ fontSize: '0.75rem', color: 'var(--color-text-muted)', margin: '2px 0 0 0' }}>
                             Enable third-party social logins for your application users.
                         </p>
@@ -340,7 +348,14 @@ export default function IntegrationsSettings({
 
             {/* 3. MAIL SECTION */}
             <div>
-                <h3 style={{ fontSize: '1rem', fontWeight: 600, margin: '0 0 4px 0' }}>Mail Delivery & Templates</h3>
+                <h3 style={{ fontSize: '1rem', fontWeight: 600, margin: '0 0 4px 0', display: 'flex', alignItems: 'center' }}>
+                    Mail Delivery & Templates
+                    <SettingInfoTooltip
+                        title="Mail Delivery — Resend.com (BYOK)"
+                        description="Connect a Resend.com API key (starts with re_) to send transactional emails from your own domain. Set a default From address (e.g. 'Acme <info@acme.com>'). Without a custom key, urBackend's shared mail quota applies. The API key is encrypted at rest."
+                        docsUrl="https://docs.ub.bitbros.in/guides/mail-platform"
+                    />
+                </h3>
                 <p style={{ fontSize: '0.75rem', color: 'var(--color-text-muted)', margin: '0 0 1rem 0' }}>
                     Transactional email providers and dynamic template engine.
                 </p>
@@ -409,7 +424,14 @@ export default function IntegrationsSettings({
 
             {/* 5. AI SERVICES (BYOK) */}
             <div>
-                <h3 style={{ fontSize: '1rem', fontWeight: 600, margin: '0 0 4px 0' }}>AI Services</h3>
+                <h3 style={{ fontSize: '1rem', fontWeight: 600, margin: '0 0 4px 0', display: 'flex', alignItems: 'center' }}>
+                    AI Services
+                    <SettingInfoTooltip
+                        title="AI Services — Project-level Groq BYOK"
+                        description="Provide a project-specific Groq API key to override the developer-level key for all AI operations in this project (schema suggestions, query generation, etc.). This key takes priority and is billed to your Groq account. Encrypted at rest; never returned by any API response."
+                        docsUrl="https://docs.ub.bitbros.in/guides/ai-byok#set-a-project-level-key"
+                    />
+                </h3>
                 <p style={{ fontSize: '0.75rem', color: 'var(--color-text-muted)', margin: '0 0 1rem 0' }}>
                     Project-level overrides for AI capabilities.
                 </p>

--- a/apps/web-dashboard/src/components/Settings/IntegrationsSettings.jsx
+++ b/apps/web-dashboard/src/components/Settings/IntegrationsSettings.jsx
@@ -256,7 +256,7 @@ export default function IntegrationsSettings({
                             OAuth2 Providers
                             <SettingInfoTooltip
                                 title="OAuth2 Social Auth Providers"
-                                description="Enable GitHub or Google social login for your application's end-users. You need to register an OAuth app on each provider's developer console, then paste the Client ID and Client Secret here. The Callback URL is auto-generated and read-only — copy it into the provider's app settings. Credentials are encrypted at rest."
+                                description="Enable GitHub or Google social login for your application's end-users. Click a provider card to open its configuration modal, select your provider, and enter your Client ID and Client Secret. The Callback URL is auto-generated and read-only — copy it into your provider's developer console. Credentials are encrypted at rest."
                                 docsUrl="https://docs.ub.bitbros.in/guides/social-auth"
                             />
                         </h3>

--- a/apps/web-dashboard/src/components/Settings/MailTemplatesForm.jsx
+++ b/apps/web-dashboard/src/components/Settings/MailTemplatesForm.jsx
@@ -246,7 +246,18 @@ export default function MailTemplatesForm({ projectId, role }) {
                 />
             )}
 
-            <SettingsCard title="Mail Templates" icon={Mail} iconColor="#60a5fa" accentColor="#3b82f6" style={{ borderColor: 'rgba(59,130,246,0.25)' }}>
+            <SettingsCard
+                title="Mail Templates"
+                icon={Mail}
+                iconColor="#60a5fa"
+                accentColor="#3b82f6"
+                style={{ borderColor: 'rgba(59,130,246,0.25)' }}
+                info={{
+                    title: 'Mail Templates',
+                    description: "Create reusable email templates for transactional messages like OTPs, welcome emails, and notifications. Templates support Handlebars-style variable interpolation: {{variable}} (HTML-escaped) and {{{raw_variable}}} (unescaped). Reference a template by its slug when calling POST /api/mail/send. A live preview is shown as you edit.",
+                    docsUrl: 'https://docs.ub.bitbros.in/guides/mail-platform'
+                }}
+            >
                 <p style={{ fontSize: '0.75rem', color: 'var(--color-text-muted)', margin: 0, lineHeight: 1.5, marginBottom: '10px' }}>
                     Create reusable subjects/bodies and preview how they render with variables. Use <code>{'{{name}}'}</code> (escaped) or <code>{'{{{name}}}'}</code> (raw) inside HTML.
                 </p>

--- a/apps/web-dashboard/src/components/Settings/SettingInfoTooltip.jsx
+++ b/apps/web-dashboard/src/components/Settings/SettingInfoTooltip.jsx
@@ -17,7 +17,7 @@ import { Info, ExternalLink, X } from 'lucide-react';
  */
 export default function SettingInfoTooltip({ title, description, docsUrl }) {
     const [open, setOpen] = useState(false);
-    const [pos, setPos] = useState({ top: 0, left: 0, align: 'left' });
+    const [pos, setPos] = useState({ top: 0, left: 0 });
     const btnRef = useRef(null);
     const popoverRef = useRef(null);
 
@@ -26,35 +26,38 @@ export default function SettingInfoTooltip({ title, description, docsUrl }) {
 
         const isMobile = window.innerWidth < 640;
         if (isMobile) {
-            setPos({ top: '50%', left: '50%', align: 'center' });
+            setPos({ top: '50%', left: '50%' });
             return;
         }
 
         const rect = btnRef.current.getBoundingClientRect();
         const POPOVER_WIDTH = 320;
-        const POPOVER_OFFSET = 8; // gap between button and popover
+        const POPOVER_OFFSET = 8;
+        const ESTIMATED_MAX_HEIGHT = 240;
+        const VIEWPORT_MARGIN = 12;
 
         // Prefer opening to the right; if not enough space, open to the left
         const spaceRight = window.innerWidth - rect.right;
         const spaceLeft = rect.left;
 
         let left;
-        let align;
         if (spaceRight >= POPOVER_WIDTH + POPOVER_OFFSET) {
             left = rect.right + POPOVER_OFFSET + window.scrollX;
-            align = 'left';
         } else if (spaceLeft >= POPOVER_WIDTH + POPOVER_OFFSET) {
             left = rect.left - POPOVER_WIDTH - POPOVER_OFFSET + window.scrollX;
-            align = 'left';
         } else {
             // Center horizontally under the button
-            left = Math.max(8, rect.left + rect.width / 2 - POPOVER_WIDTH / 2 + window.scrollX);
-            align = 'left';
+            left = Math.max(VIEWPORT_MARGIN, rect.left + rect.width / 2 - POPOVER_WIDTH / 2 + window.scrollX);
         }
 
-        const top = rect.top + window.scrollY;
+        // Vertical placement clamped to viewport bounds
+        let top = rect.top + window.scrollY;
+        const maxTop = window.scrollY + window.innerHeight - ESTIMATED_MAX_HEIGHT - VIEWPORT_MARGIN;
+        if (top > maxTop) {
+            top = Math.max(window.scrollY + VIEWPORT_MARGIN, maxTop);
+        }
 
-        setPos({ top, left, align });
+        setPos({ top, left });
     }, []);
 
     const handleOpen = (e) => {
@@ -63,9 +66,19 @@ export default function SettingInfoTooltip({ title, description, docsUrl }) {
         setOpen(true);
     };
 
-    const handleClose = useCallback(() => setOpen(false), []);
+    const handleClose = useCallback(() => {
+        setOpen(false);
+        btnRef.current?.focus();
+    }, []);
 
-    // Click outside
+    // Focus dialog when opened
+    useEffect(() => {
+        if (open) {
+            popoverRef.current?.focus();
+        }
+    }, [open]);
+
+    // Click outside & Escape key listeners
     useEffect(() => {
         if (!open) return;
 
@@ -130,6 +143,7 @@ export default function SettingInfoTooltip({ title, description, docsUrl }) {
                 onClick={handleOpen}
                 aria-label={`More info about ${title}`}
                 aria-expanded={open}
+                aria-haspopup="dialog"
                 title={`About: ${title}`}
                 style={{
                     display: 'inline-flex',
@@ -179,8 +193,10 @@ export default function SettingInfoTooltip({ title, description, docsUrl }) {
 
                     <div
                         ref={popoverRef}
-                        role="tooltip"
-                        aria-live="polite"
+                        role="dialog"
+                        aria-label={title}
+                        aria-modal={isMobile ? "true" : "false"}
+                        tabIndex={-1}
                         style={{
                             ...popoverStyle,
                             background: 'var(--color-bg-card, #161b22)',
@@ -188,6 +204,7 @@ export default function SettingInfoTooltip({ title, description, docsUrl }) {
                             borderRadius: '10px',
                             boxShadow: '0 8px 32px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.04)',
                             overflow: 'hidden',
+                            outline: 'none',
                             animation: 'sitTooltipIn 0.12s ease',
                         }}
                     >

--- a/apps/web-dashboard/src/components/Settings/SettingInfoTooltip.jsx
+++ b/apps/web-dashboard/src/components/Settings/SettingInfoTooltip.jsx
@@ -1,0 +1,282 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import ReactDOM from 'react-dom';
+import { Info, ExternalLink, X } from 'lucide-react';
+
+/**
+ * SettingInfoTooltip
+ *
+ * Renders a small circular `i` button next to a label/title.
+ * On click, opens a rich popover card (via React Portal → document.body, z-index 9999)
+ * with a description and a "Learn more" docs link.
+ *
+ * Props:
+ *   title       {string} - Popover heading
+ *   description {string} - Detailed explanation (supports simple HTML via dangerouslySetInnerHTML
+ *                          if needed, but plain text is preferred for safety)
+ *   docsUrl     {string} - Full URL to the relevant docs.ub.bitbros.in page
+ */
+export default function SettingInfoTooltip({ title, description, docsUrl }) {
+    const [open, setOpen] = useState(false);
+    const [pos, setPos] = useState({ top: 0, left: 0, align: 'left' });
+    const btnRef = useRef(null);
+    const popoverRef = useRef(null);
+
+    const calculatePosition = useCallback(() => {
+        if (!btnRef.current) return;
+
+        const isMobile = window.innerWidth < 640;
+        if (isMobile) {
+            setPos({ top: '50%', left: '50%', align: 'center' });
+            return;
+        }
+
+        const rect = btnRef.current.getBoundingClientRect();
+        const POPOVER_WIDTH = 320;
+        const POPOVER_OFFSET = 8; // gap between button and popover
+
+        // Prefer opening to the right; if not enough space, open to the left
+        const spaceRight = window.innerWidth - rect.right;
+        const spaceLeft = rect.left;
+
+        let left;
+        let align;
+        if (spaceRight >= POPOVER_WIDTH + POPOVER_OFFSET) {
+            left = rect.right + POPOVER_OFFSET + window.scrollX;
+            align = 'left';
+        } else if (spaceLeft >= POPOVER_WIDTH + POPOVER_OFFSET) {
+            left = rect.left - POPOVER_WIDTH - POPOVER_OFFSET + window.scrollX;
+            align = 'left';
+        } else {
+            // Center horizontally under the button
+            left = Math.max(8, rect.left + rect.width / 2 - POPOVER_WIDTH / 2 + window.scrollX);
+            align = 'left';
+        }
+
+        const top = rect.top + window.scrollY;
+
+        setPos({ top, left, align });
+    }, []);
+
+    const handleOpen = (e) => {
+        e.stopPropagation();
+        calculatePosition();
+        setOpen(true);
+    };
+
+    const handleClose = useCallback(() => setOpen(false), []);
+
+    // Click outside
+    useEffect(() => {
+        if (!open) return;
+
+        const onClickOutside = (e) => {
+            if (
+                popoverRef.current && !popoverRef.current.contains(e.target) &&
+                btnRef.current && !btnRef.current.contains(e.target)
+            ) {
+                handleClose();
+            }
+        };
+
+        const onKeyDown = (e) => {
+            if (e.key === 'Escape') handleClose();
+        };
+
+        document.addEventListener('mousedown', onClickOutside);
+        document.addEventListener('keydown', onKeyDown);
+        return () => {
+            document.removeEventListener('mousedown', onClickOutside);
+            document.removeEventListener('keydown', onKeyDown);
+        };
+    }, [open, handleClose]);
+
+    // Recalculate on scroll / resize
+    useEffect(() => {
+        if (!open) return;
+        const recalc = () => calculatePosition();
+        window.addEventListener('scroll', recalc, true);
+        window.addEventListener('resize', recalc);
+        return () => {
+            window.removeEventListener('scroll', recalc, true);
+            window.removeEventListener('resize', recalc);
+        };
+    }, [open, calculatePosition]);
+
+    const isMobile = typeof window !== 'undefined' && window.innerWidth < 640;
+
+    const popoverStyle = isMobile
+        ? {
+            position: 'fixed',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            zIndex: 9999,
+            width: 'calc(100vw - 32px)',
+            maxWidth: '360px',
+        }
+        : {
+            position: 'absolute',
+            top: pos.top,
+            left: pos.left,
+            zIndex: 9999,
+            width: '320px',
+        };
+
+    return (
+        <>
+            <button
+                ref={btnRef}
+                type="button"
+                onClick={handleOpen}
+                aria-label={`More info about ${title}`}
+                aria-expanded={open}
+                title={`About: ${title}`}
+                style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: '16px',
+                    height: '16px',
+                    borderRadius: '50%',
+                    border: '1px solid rgba(255,255,255,0.15)',
+                    background: 'rgba(255,255,255,0.05)',
+                    color: 'var(--color-text-muted)',
+                    cursor: 'pointer',
+                    padding: 0,
+                    flexShrink: 0,
+                    transition: 'border-color 0.15s ease, color 0.15s ease, background 0.15s ease',
+                    verticalAlign: 'middle',
+                    marginLeft: '5px',
+                }}
+                onMouseEnter={(e) => {
+                    e.currentTarget.style.borderColor = 'var(--color-primary)';
+                    e.currentTarget.style.color = 'var(--color-primary)';
+                    e.currentTarget.style.background = 'rgba(62,207,142,0.08)';
+                }}
+                onMouseLeave={(e) => {
+                    e.currentTarget.style.borderColor = 'rgba(255,255,255,0.15)';
+                    e.currentTarget.style.color = 'var(--color-text-muted)';
+                    e.currentTarget.style.background = 'rgba(255,255,255,0.05)';
+                }}
+            >
+                <Info size={9} strokeWidth={2.5} />
+            </button>
+
+            {open && ReactDOM.createPortal(
+                <>
+                    {/* Mobile backdrop */}
+                    {isMobile && (
+                        <div
+                            onClick={handleClose}
+                            style={{
+                                position: 'fixed',
+                                inset: 0,
+                                background: 'rgba(0,0,0,0.5)',
+                                zIndex: 9998,
+                            }}
+                        />
+                    )}
+
+                    <div
+                        ref={popoverRef}
+                        role="tooltip"
+                        aria-live="polite"
+                        style={{
+                            ...popoverStyle,
+                            background: 'var(--color-bg-card, #161b22)',
+                            border: '1px solid var(--color-border)',
+                            borderRadius: '10px',
+                            boxShadow: '0 8px 32px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.04)',
+                            overflow: 'hidden',
+                            animation: 'sitTooltipIn 0.12s ease',
+                        }}
+                    >
+                        {/* Header */}
+                        <div style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            padding: '10px 12px 8px',
+                            borderBottom: '1px solid var(--color-border)',
+                        }}>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '7px' }}>
+                                <Info size={13} color="var(--color-primary)" />
+                                <span style={{ fontSize: '0.8rem', fontWeight: 700, color: '#fff' }}>{title}</span>
+                            </div>
+                            <button
+                                type="button"
+                                onClick={handleClose}
+                                aria-label="Close info"
+                                style={{
+                                    background: 'none',
+                                    border: 'none',
+                                    color: 'var(--color-text-muted)',
+                                    cursor: 'pointer',
+                                    padding: '2px',
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    borderRadius: '3px',
+                                }}
+                                onMouseEnter={(e) => { e.currentTarget.style.color = '#fff'; }}
+                                onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--color-text-muted)'; }}
+                            >
+                                <X size={13} />
+                            </button>
+                        </div>
+
+                        {/* Body */}
+                        <div style={{ padding: '10px 12px' }}>
+                            <p style={{
+                                fontSize: '0.76rem',
+                                color: 'var(--color-text-muted)',
+                                lineHeight: 1.6,
+                                margin: 0,
+                            }}>
+                                {description}
+                            </p>
+                        </div>
+
+                        {/* Footer — Learn more */}
+                        {docsUrl && (
+                            <div style={{
+                                padding: '8px 12px',
+                                borderTop: '1px solid var(--color-border)',
+                                background: 'rgba(255,255,255,0.02)',
+                            }}>
+                                <a
+                                    href={docsUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    onClick={(e) => e.stopPropagation()}
+                                    style={{
+                                        display: 'inline-flex',
+                                        alignItems: 'center',
+                                        gap: '5px',
+                                        fontSize: '0.73rem',
+                                        fontWeight: 600,
+                                        color: 'var(--color-primary)',
+                                        textDecoration: 'none',
+                                        transition: 'opacity 0.15s',
+                                    }}
+                                    onMouseEnter={(e) => { e.currentTarget.style.opacity = '0.75'; }}
+                                    onMouseLeave={(e) => { e.currentTarget.style.opacity = '1'; }}
+                                >
+                                    <ExternalLink size={11} />
+                                    Learn more in docs
+                                </a>
+                            </div>
+                        )}
+                    </div>
+
+                    <style>{`
+                        @keyframes sitTooltipIn {
+                            from { opacity: 0; transform: translateY(-4px) ${isMobile ? 'translate(-50%,-50%)' : ''}; }
+                            to   { opacity: 1; transform: translateY(0)   ${isMobile ? 'translate(-50%,-50%)' : ''}; }
+                        }
+                    `}</style>
+                </>,
+                document.body
+            )}
+        </>
+    );
+}

--- a/apps/web-dashboard/src/components/Settings/StorageConfigForm.jsx
+++ b/apps/web-dashboard/src/components/Settings/StorageConfigForm.jsx
@@ -76,7 +76,17 @@ export default function StorageConfigForm({ project, projectId, onProjectUpdate,
     };
 
     return (
-        <SettingsCard title="Storage (BYOS)" icon={HardDrive} iconColor="#34d399" accentColor="#34d399">
+        <SettingsCard
+            title="Storage (BYOS)"
+            icon={HardDrive}
+            iconColor="#34d399"
+            accentColor="#34d399"
+            info={{
+                title: 'Storage — Bring Your Own Storage (BYOS)',
+                description: "Connect your own cloud storage bucket for file uploads. Supported providers: Supabase Storage, AWS S3, Cloudflare R2, and Google Cloud Storage. urBackend proxies file operations through the Public API (/api/storage) using signed URLs. Your bucket credentials are encrypted at rest.",
+                docsUrl: 'https://docs.ub.bitbros.in/guides/storage'
+            }}
+        >
             {showRemoveModal && (
                 <ConfirmationModal
                     open={showRemoveModal}

--- a/apps/web-dashboard/src/components/Settings/formPrimitives.jsx
+++ b/apps/web-dashboard/src/components/Settings/formPrimitives.jsx
@@ -1,11 +1,26 @@
 import React from 'react';
+import SettingInfoTooltip from './SettingInfoTooltip';
 
-export function FormField({ label, hint, children }) {
+/**
+ * FormField
+ * Wraps a label + children + optional hint text.
+ * @param {string|ReactNode} label
+ * @param {string|ReactNode} hint
+ * @param {{ title, description, docsUrl }} [info] - If provided, renders an info (i) button next to the label
+ */
+export function FormField({ label, hint, info, children }) {
     return (
         <div className="form-group">
             {label && (
-                <label className="form-label" style={{ display: 'block', marginBottom: '5px', fontSize: '0.75rem', color: 'var(--color-text-muted)', fontWeight: 500 }}>
-                    {label}
+                <label className="form-label" style={{ display: 'flex', alignItems: 'center', marginBottom: '5px', fontSize: '0.75rem', color: 'var(--color-text-muted)', fontWeight: 500 }}>
+                    <span>{label}</span>
+                    {info && (
+                        <SettingInfoTooltip
+                            title={info.title}
+                            description={info.description}
+                            docsUrl={info.docsUrl}
+                        />
+                    )}
                 </label>
             )}
             {children}
@@ -14,17 +29,29 @@ export function FormField({ label, hint, children }) {
     );
 }
 
-export function SettingsCard({ title, icon: Icon, iconColor, accentColor, children, style = {} }) {
+/**
+ * SettingsCard
+ * Card wrapper with optional left accent bar, icon, and title.
+ * @param {{ title, description, docsUrl }} [info] - If provided, renders an info (i) button next to the card title
+ */
+export function SettingsCard({ title, icon: Icon, iconColor, accentColor, info, children, style = {} }) {
     return (
-        <div className="glass-card" style={{ borderRadius: '8px', position: 'relative', overflow: 'hidden', ...style }}>
+        <div className="glass-card" style={{ borderRadius: '8px', position: 'relative', overflow: 'visible', ...style }}>
             {accentColor && (
-                <div style={{ position: 'absolute', top: 0, left: 0, width: '3px', height: '100%', background: accentColor }} />
+                <div style={{ position: 'absolute', top: 0, left: 0, width: '3px', height: '100%', background: accentColor, borderRadius: '8px 0 0 8px' }} />
             )}
             <div style={{ padding: '1rem', paddingLeft: accentColor ? '1.25rem' : '1rem' }}>
                 {title && (
                     <div style={{ display: 'flex', alignItems: 'center', gap: '7px', marginBottom: '1rem' }}>
                         {Icon && <Icon size={14} color={iconColor || 'var(--color-primary)'} />}
-                        <h3 style={{ fontSize: '0.85rem', fontWeight: 600 }}>{title}</h3>
+                        <h3 style={{ fontSize: '0.85rem', fontWeight: 600, margin: 0 }}>{title}</h3>
+                        {info && (
+                            <SettingInfoTooltip
+                                title={info.title}
+                                description={info.description}
+                                docsUrl={info.docsUrl}
+                            />
+                        )}
                     </div>
                 )}
                 {children}
@@ -32,3 +59,4 @@ export function SettingsCard({ title, icon: Icon, iconColor, accentColor, childr
         </div>
     );
 }
+

--- a/apps/web-dashboard/src/components/Settings/formPrimitives.jsx
+++ b/apps/web-dashboard/src/components/Settings/formPrimitives.jsx
@@ -12,8 +12,10 @@ export function FormField({ label, hint, info, children }) {
     return (
         <div className="form-group">
             {label && (
-                <label className="form-label" style={{ display: 'flex', alignItems: 'center', marginBottom: '5px', fontSize: '0.75rem', color: 'var(--color-text-muted)', fontWeight: 500 }}>
-                    <span>{label}</span>
+                <div style={{ display: 'flex', alignItems: 'center', marginBottom: '5px' }}>
+                    <label className="form-label" style={{ margin: 0, fontSize: '0.75rem', color: 'var(--color-text-muted)', fontWeight: 500 }}>
+                        {label}
+                    </label>
                     {info && (
                         <SettingInfoTooltip
                             title={info.title}
@@ -21,7 +23,7 @@ export function FormField({ label, hint, info, children }) {
                             docsUrl={info.docsUrl}
                         />
                     )}
-                </label>
+                </div>
             )}
             {children}
             {hint && <small style={{ display: 'block', marginTop: '5px', fontSize: '0.68rem', color: 'var(--color-text-muted)', lineHeight: 1.4 }}>{hint}</small>}

--- a/apps/web-dashboard/src/pages/ProjectSettings.jsx
+++ b/apps/web-dashboard/src/pages/ProjectSettings.jsx
@@ -6,6 +6,7 @@ import toast from "react-hot-toast";
 import {
     Trash2, AlertTriangle, Settings, Database, Sliders
 } from "lucide-react";
+import SettingInfoTooltip from "../components/Settings/SettingInfoTooltip";
 import ConfirmationModal from "./ConfirmationModal";
 import SectionHeader from "../components/Dashboard/SectionHeader";
 import IntegrationsSettings from "../components/Settings/IntegrationsSettings";
@@ -224,7 +225,14 @@ export default function ProjectSettings() {
                         <SectionHeader title="General" />
                         <SettingsCard title="Project Info" icon={Settings} iconColor="var(--color-primary)">
                             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px', alignItems: 'end' }}>
-                                <FormField label="Project Name">
+                                <FormField
+                                    label="Project Name"
+                                    info={{
+                                        title: 'Project Name',
+                                        description: 'The display name for this project shown across the dashboard and SDKs. Renaming does not affect your API keys or existing data.',
+                                        docsUrl: 'https://docs.ub.bitbros.in/introduction'
+                                    }}
+                                >
                                     <input
                                         type="text"
                                         className="input-field"
@@ -237,6 +245,11 @@ export default function ProjectSettings() {
                                 <FormField
                                     label="Site URL"
                                     hint={<>Used by Social Auth to redirect to <code>/auth/callback</code></>}
+                                    info={{
+                                        title: 'Site URL',
+                                        description: 'The root URL of your frontend application (e.g. https://myapp.com). After a successful social login (GitHub/Google), urBackend redirects users to <SiteUrl>/auth/callback. Leave blank if you are not using Social Auth.',
+                                        docsUrl: 'https://docs.ub.bitbros.in/guides/social-auth'
+                                    }}
                                 >
                                     <input
                                         type="url"
@@ -277,7 +290,14 @@ export default function ProjectSettings() {
                             <div className="glass-card" style={{ borderRadius: '8px', border: '1px solid rgba(234,84,85,0.25)', background: 'rgba(234,84,85,0.02)', padding: '1rem' }}>
                                 <div style={{ display: 'flex', gap: '7px', alignItems: 'center', marginBottom: '0.75rem', color: '#ea5455' }}>
                                     <AlertTriangle size={14} />
-                                    <h3 style={{ fontSize: '0.85rem', fontWeight: 600 }}>Delete Project</h3>
+                                    <h3 style={{ fontSize: '0.85rem', fontWeight: 600, display: 'flex', alignItems: 'center' }}>
+                                        Delete Project
+                                        <SettingInfoTooltip
+                                            title="Delete Project"
+                                            description="Permanently deletes this project and ALL associated data: every collection, every document, all uploaded files, auth users, API keys, and team memberships. This cannot be undone. Export your data before proceeding."
+                                            docsUrl="https://docs.ub.bitbros.in/concepts/collections-schemas"
+                                        />
+                                    </h3>
                                 </div>
                                 <p style={{ color: 'var(--color-text-muted)', marginBottom: '1rem', fontSize: '0.75rem', lineHeight: 1.5 }}>
                                     This will permanently delete <strong style={{ color: '#fff' }}>{project?.name}</strong> and all associated data including collections, files, and users. This action cannot be undone.

--- a/apps/web-dashboard/src/pages/ProjectSettings.jsx
+++ b/apps/web-dashboard/src/pages/ProjectSettings.jsx
@@ -247,7 +247,7 @@ export default function ProjectSettings() {
                                     hint={<>Used by Social Auth to redirect to <code>/auth/callback</code></>}
                                     info={{
                                         title: 'Site URL',
-                                        description: 'The root URL of your frontend application (e.g. https://myapp.com). After a successful social login (GitHub/Google), urBackend redirects users to <SiteUrl>/auth/callback. Leave blank if you are not using Social Auth.',
+                                        description: 'The root URL of your frontend application (e.g. https://myapp.com). After a successful social login (GitHub/Google), urBackend redirects users to your Site URL at /auth/callback. Leave blank if you are not using Social Auth.',
                                         docsUrl: 'https://docs.ub.bitbros.in/guides/social-auth'
                                     }}
                                 >
@@ -295,7 +295,6 @@ export default function ProjectSettings() {
                                         <SettingInfoTooltip
                                             title="Delete Project"
                                             description="Permanently deletes this project and ALL associated data: every collection, every document, all uploaded files, auth users, API keys, and team memberships. This cannot be undone. Export your data before proceeding."
-                                            docsUrl="https://docs.ub.bitbros.in/concepts/collections-schemas"
                                         />
                                     </h3>
                                 </div>

--- a/apps/web-dashboard/src/pages/Settings.jsx
+++ b/apps/web-dashboard/src/pages/Settings.jsx
@@ -248,7 +248,7 @@ if (pageLoading) return <SettingsSkeleton />;
                             AI Integration (BYOK)
                             <SettingInfoTooltip
                                 title="AI Integration — Bring Your Own Key"
-                                description="Connect your personal Groq API key (starts with gsk_) to bypass urBackend's platform session cap. Free plan: 5 AI sessions/month. Pro: 20/month. With BYOK, your AI usage goes directly to your own Groq account — no urBackend cap applies. Keys are encrypted at rest and never returned by the API."
+                                description="Connect your personal Groq API key (starts with gsk_) to bypass platform session limits across your projects. With BYOK, all AI queries are billed directly to your Groq account rather than urBackend's plan quotas. Keys are encrypted at rest and never returned by the API."
                                 docsUrl="https://docs.ub.bitbros.in/guides/ai-byok"
                             />
                         </h3>

--- a/apps/web-dashboard/src/pages/Settings.jsx
+++ b/apps/web-dashboard/src/pages/Settings.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext';
 import { useLocation, useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { Lock, Trash2, AlertTriangle, Save, CheckCircle, Cpu, Eye, EyeOff } from 'lucide-react';
+import SettingInfoTooltip from '../components/Settings/SettingInfoTooltip';
 import ConfirmationModal from './ConfirmationModal';
 import PATManager from '../components/PATManager';
 
@@ -190,7 +191,14 @@ if (pageLoading) return <SettingsSkeleton />;
                         <Lock size={20} />
                     </div>
                     <div>
-                        <h3 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '2px' }}>Change Password</h3>
+                        <h3 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '2px', display: 'flex', alignItems: 'center' }}>
+                            Change Password
+                            <SettingInfoTooltip
+                                title="Change Password"
+                                description="Update your developer account password. You'll need to enter your current password to confirm the change. Use a strong, unique password to protect your account and all associated projects."
+                                docsUrl="https://docs.ub.bitbros.in/security"
+                            />
+                        </h3>
                         <p style={{ fontSize: '0.85rem', color: 'var(--color-text-muted)' }}>Secure your account with a strong password.</p>
                     </div>
                 </div>
@@ -236,7 +244,14 @@ if (pageLoading) return <SettingsSkeleton />;
                         <Cpu size={20} />
                     </div>
                     <div>
-                        <h3 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '2px' }}>AI Integration (BYOK)</h3>
+                        <h3 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '2px', display: 'flex', alignItems: 'center' }}>
+                            AI Integration (BYOK)
+                            <SettingInfoTooltip
+                                title="AI Integration — Bring Your Own Key"
+                                description="Connect your personal Groq API key (starts with gsk_) to bypass urBackend's platform session cap. Free plan: 5 AI sessions/month. Pro: 20/month. With BYOK, your AI usage goes directly to your own Groq account — no urBackend cap applies. Keys are encrypted at rest and never returned by the API."
+                                docsUrl="https://docs.ub.bitbros.in/guides/ai-byok"
+                            />
+                        </h3>
                         <p style={{ fontSize: '0.85rem', color: 'var(--color-text-muted)' }}>Bring Your Own Key to bypass platform rate limits for AI queries.</p>
                     </div>
                 </div>
@@ -307,7 +322,14 @@ if (pageLoading) return <SettingsSkeleton />;
                         <AlertTriangle size={20} />
                     </div>
                     <div>
-                        <h3 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '2px' }}>Danger Zone</h3>
+                        <h3 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '2px', display: 'flex', alignItems: 'center' }}>
+                            Danger Zone
+                            <SettingInfoTooltip
+                                title="Delete Account"
+                                description="Permanently and irreversibly deletes your developer account. All projects, API keys, collections, storage files, and team memberships will be immediately erased. This action cannot be undone — make sure you've exported any data you need before proceeding."
+                                docsUrl="https://docs.ub.bitbros.in/security"
+                            />
+                        </h3>
                         <p style={{ fontSize: '0.85rem', color: '#ea5455', opacity: 0.8 }}>Irreversible account actions.</p>
                     </div>
                 </div>


### PR DESCRIPTION
### 📝 Summary
Added an interactive info (`i`) button to every option across **User Settings** and **Project Settings**. Clicking it opens a help popover with details and a direct "Learn more" link to the relevant docs on [docs.ub.bitbros.in](https://docs.ub.bitbros.in).

---

### ✨ Highlights
- **New `SettingInfoTooltip`**: Portal-rendered (`z-index: 9999`) with backdrop, auto-positioning, and mobile-friendly centering.
- **`formPrimitives` Integration**: Added `info` prop to `FormField` and `SettingsCard` for consistent UI.
- **Full Coverage**:
  - **Account**: Password, Email Verification, AI BYOK, PAT Tokens, Delete Account.
  - **Project**: General Info, Site URL, CORS / Allowed Domains, OAuth2, MongoDB BYOD, Resend Mail, Mail Templates, Storage BYOS, Project AI Key, Delete Project.

---

### 🧪 Testing
- [x] `npm run lint` — passed
- [x] `npm run build` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual information tooltips throughout project, account, integration, storage, database, email, and security settings.
  * Tooltips provide explanations, usage guidance, security details, and links to relevant documentation.
  * Added responsive tooltip behavior with mobile and desktop layouts, outside-click dismissal, and Escape-key support.
  * Expanded settings cards and form fields to display optional help information alongside titles and labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->