### PR TITLE
feat(ai): comprehensive AI Collection Creator improvements, rate-limiting fixes, and interactive Schema Canvas visualize

### DIFF
--- a/apps/dashboard-api/src/controllers/ai.controller.js
+++ b/apps/dashboard-api/src/controllers/ai.controller.js
@@ -1,3 +1,4 @@
+const mongoose = require('mongoose');
 const { Project, Developer } = require('@urbackend/common/src/models');
 const { forwardToPythonService } = require('../utils/internalPythonClient');
 const { AppError, ApiResponse, getProjectAccessQuery, resolveEffectivePlan } = require('@urbackend/common');
@@ -13,7 +14,6 @@ const queryBuilder = async (req, res, next) => {
         const { projectId } = req.params;
         const { collectionName, prompt } = req.body;
 
-        const mongoose = require('mongoose');
         if (!mongoose.Types.ObjectId.isValid(projectId)) {
             throw new AppError(400, "Invalid project ID");
         }
@@ -36,11 +36,11 @@ const queryBuilder = async (req, res, next) => {
             throw new AppError(403, "Cannot query the users collection via AI");
         }
 
-        // 1. Load collection and project details
+        // 1. Load collection and project details (including BYOK fields in a single query)
         const project = await Project.findOne({
             _id: projectId,
             ...getProjectAccessQuery(req.user._id)
-        });
+        }).select('+byok.groqKey.encrypted +byok.groqKey.iv +byok.groqKey.tag');
 
         if (!project) {
             throw new AppError(404, "Project not found or access denied");
@@ -80,20 +80,20 @@ const queryBuilder = async (req, res, next) => {
         let resolvedKey = null;
 
         // 1. Check project-level BYOK
-        const projectByok = await Project.findOne({
-            _id: projectId,
-            ...getProjectAccessQuery(req.user._id)
-        })
-            .select('+byok.groqKey.encrypted +byok.groqKey.iv +byok.groqKey.tag')
-            .lean();
-        if (projectByok?.byok?.groqKey?.encrypted) {
-            resolvedKey = decrypt(projectByok.byok.groqKey);
+        if (project.byok?.groqKey?.encrypted) {
+            resolvedKey = decrypt(project.byok.groqKey);
+            if (!resolvedKey) {
+                console.warn(`[QueryBuilder] Project-level BYOK key decryption failed for project ${projectId}`);
+            }
         }
 
         // 2. Fallback to developer-level BYOK
         const dev = await Developer.findById(req.user._id).select('+byok');
         if (!resolvedKey && dev?.byok?.groqKey?.encrypted) {
             resolvedKey = decrypt(dev.byok.groqKey);
+            if (!resolvedKey) {
+                console.warn(`[QueryBuilder] Developer-level BYOK key decryption failed for developer ${req.user._id}`);
+            }
         }
 
         // 3. Encrypt for secure transit to Python
@@ -179,7 +179,6 @@ const collectionCreator = async (req, res, next) => {
         }
         const safeUserMessage = userMessage.trim();
 
-        const mongoose = require('mongoose');
         if (!mongoose.Types.ObjectId.isValid(projectId)) {
             throw new AppError(400, "Invalid project ID");
         }
@@ -208,17 +207,31 @@ const collectionCreator = async (req, res, next) => {
         } catch (e) {
             console.warn("Invalid session data in Redis, resetting chat transcript");
         }
-        let iterations = iterStr ? parseInt(iterStr, 10) : 0;
+
+        // Reset stale iteration counter if session has expired
+        let iterations = 0;
+        if (sessionStr && iterStr) {
+            iterations = parseInt(iterStr, 10) || 0;
+        } else if (iterStr && !sessionStr) {
+            await redis.del(iterKey);
+            iterations = 0;
+        }
 
         // 3. BYOK resolution
         let resolvedKey = null;
         if (project.byok?.groqKey?.encrypted) {
             resolvedKey = decrypt(project.byok.groqKey);
+            if (!resolvedKey) {
+                console.warn(`[CollectionCreator] Project-level BYOK key decryption failed for project ${projectId}`);
+            }
         }
 
         const dev = await Developer.findById(req.user._id).select('+byok +plan +trialEndsAt +subscriptionId');
         if (!resolvedKey && dev?.byok?.groqKey?.encrypted) {
             resolvedKey = decrypt(dev.byok.groqKey);
+            if (!resolvedKey) {
+                console.warn(`[CollectionCreator] Developer-level BYOK key decryption failed for developer ${req.user._id}`);
+            }
         }
 
         const encryptedByok = resolvedKey ? { groqKey: encryptForTransit(resolvedKey) } : null;
@@ -251,35 +264,41 @@ const collectionCreator = async (req, res, next) => {
         let safeSchema = null;
         
         if (['schema', 'complete'].includes(aiResponse.type) && Array.isArray(aiResponse.schema)) {
+            const sanitizeFields = (fields) => {
+                return (fields || []).filter(f => f.name && allowedTypes.has(f.type)).map(f => {
+                    const fieldDef = {
+                        name: f.name,
+                        type: f.type,
+                        required: !!f.required
+                    };
+                    if (f.type === 'Ref') {
+                        fieldDef.ref = f.ref || 'users';
+                    } else if (f.type === 'Array') {
+                        fieldDef.items = f.items || { type: 'String' };
+                    } else if (f.type === 'Object' && Array.isArray(f.fields) && f.fields.length > 0) {
+                        fieldDef.fields = sanitizeFields(f.fields);
+                    }
+                    if (f.unique !== undefined && !['Array', 'Object', 'Ref'].includes(f.type)) {
+                        fieldDef.unique = !!f.unique;
+                    }
+                    return fieldDef;
+                });
+            };
+
             safeSchema = aiResponse.schema
                 .filter(c => c.collection && c.collection.toLowerCase() !== 'users')
-                .map(c => {
-                    const sanitizedFields = (c.fields || []).filter(f => f.name && allowedTypes.has(f.type)).map(f => {
-                       const fieldDef = {
-                           name: f.name,
-                           type: f.type,
-                           required: !!f.required
-                       };
-                       if (f.type === 'Ref') {
-                           fieldDef.ref = f.ref || 'users';
-                       } else if (f.type === 'Array') {
-                           fieldDef.items = f.items || { type: 'String' };
-                       }
-                       return fieldDef;
-                    });
-                    return {
-                        collection: c.collection,
-                        fields: sanitizedFields
-                    };
-                })
+                .map(c => ({
+                    collection: c.collection,
+                    fields: sanitizeFields(c.fields)
+                }))
                 .filter(c => c.fields.length > 0);
         }
 
-        // 7. Save session
+        // 7. Save session & counter with TTL
         session.messages.push({ role: "assistant", content: aiResponse.message });
         if (!hasByok) {
            iterations += 1;
-           await redis.set(iterKey, iterations.toString());
+           await redis.set(iterKey, iterations.toString(), 'EX', 7200);
         }
         await redis.set(sessionKey, JSON.stringify(session), 'EX', 7200);
 
@@ -287,7 +306,8 @@ const collectionCreator = async (req, res, next) => {
             type: aiResponse.type,
             message: aiResponse.message,
             schema: safeSchema,
-            iterationsLeft: hasByok ? null : Math.max(0, PLATFORM_ITERATION_LIMIT - iterations)
+            iterationsLeft: hasByok ? null : Math.max(0, PLATFORM_ITERATION_LIMIT - iterations),
+            iterationLimit: hasByok ? null : PLATFORM_ITERATION_LIMIT
         }, "Agent responded successfully").send(res);
 
     } catch (error) {
@@ -318,7 +338,10 @@ const collectionCreator = async (req, res, next) => {
 const clearCollectionCreatorSession = async (req, res, next) => {
     try {
         const { projectId } = req.params;
-        await redis.del(ccSessionKey(projectId, req.user._id));
+        await Promise.all([
+            redis.del(ccSessionKey(projectId, req.user._id)),
+            redis.del(ccIterationsKey(projectId, req.user._id))
+        ]);
         return new ApiResponse({}, "Session cleared").send(res);
     } catch(err) {
         console.error("clearCollectionCreatorSession error", err);
@@ -331,3 +354,4 @@ module.exports = {
     collectionCreator,
     clearCollectionCreatorSession
 };
+

--- a/apps/dashboard-api/src/controllers/ai.controller.js
+++ b/apps/dashboard-api/src/controllers/ai.controller.js
@@ -166,7 +166,33 @@ const ccSessionKey = (projectId, developerId) =>
 const ccIterationsKey = (projectId, developerId) =>
   `ai:cc:iterations:${projectId}:${developerId}`;
 
+const LUA_RESERVE_ITERATION = `
+local sessionExists = redis.call('EXISTS', KEYS[2])
+local current = redis.call('GET', KEYS[1])
+local count = tonumber(current) or 0
+
+if sessionExists == 0 and count > 0 then
+    count = 0
+    redis.call('SET', KEYS[1], '0')
+end
+
+if count >= tonumber(ARGV[1]) then
+    return {0, count}
+end
+
+local nextVal = redis.call('INCR', KEYS[1])
+redis.call('EXPIRE', KEYS[1], ARGV[2])
+if sessionExists == 1 then
+    redis.call('EXPIRE', KEYS[2], ARGV[2])
+end
+return {1, nextVal}
+`;
+
 const collectionCreator = async (req, res, next) => {
+    let reservedIteration = false;
+    let iterKey = null;
+    let hasByok = false;
+
     try {
         const { projectId } = req.params;
         const { userMessage } = req.body;
@@ -195,26 +221,14 @@ const collectionCreator = async (req, res, next) => {
 
         // 2. Load Redis session
         const sessionKey = ccSessionKey(projectId, req.user._id);
-        const iterKey = ccIterationsKey(projectId, req.user._id);
-        const [sessionStr, iterStr] = await Promise.all([
-            redis.get(sessionKey),
-            redis.get(iterKey)
-        ]);
+        iterKey = ccIterationsKey(projectId, req.user._id);
+        const sessionStr = await redis.get(sessionKey);
 
         let session = { messages: [], hasByok: false };
         try {
             if (sessionStr) session = JSON.parse(sessionStr);
         } catch (e) {
             console.warn("Invalid session data in Redis, resetting chat transcript");
-        }
-
-        // Reset stale iteration counter if session has expired
-        let iterations = 0;
-        if (sessionStr && iterStr) {
-            iterations = parseInt(iterStr, 10) || 0;
-        } else if (iterStr && !sessionStr) {
-            await redis.del(iterKey);
-            iterations = 0;
         }
 
         // 3. BYOK resolution
@@ -235,12 +249,26 @@ const collectionCreator = async (req, res, next) => {
         }
 
         const encryptedByok = resolvedKey ? { groqKey: encryptForTransit(resolvedKey) } : null;
-        const hasByok = !!encryptedByok;
+        hasByok = !!encryptedByok;
 
-        // 4. Iteration limit check
+        // 4. Atomic iteration reservation before calling Python service
         const PLATFORM_ITERATION_LIMIT = 3;
-        if (!hasByok && iterations >= PLATFORM_ITERATION_LIMIT) {
-            throw new AppError(403, "AI iteration limit reached (3/3 on platform key). Add your Groq API key in Settings for unlimited usage.");
+        let iterations = 0;
+
+        if (!hasByok) {
+            const [allowed, newCount] = await redis.eval(
+                LUA_RESERVE_ITERATION,
+                2,
+                iterKey,
+                sessionKey,
+                PLATFORM_ITERATION_LIMIT,
+                7200
+            );
+            if (allowed === 0) {
+                throw new AppError(403, "AI iteration limit reached (3/3 on platform key). Add your Groq API key in Settings for unlimited usage.");
+            }
+            reservedIteration = true;
+            iterations = newCount;
         }
 
         // 5. Update session
@@ -274,7 +302,17 @@ const collectionCreator = async (req, res, next) => {
                     if (f.type === 'Ref') {
                         fieldDef.ref = f.ref || 'users';
                     } else if (f.type === 'Array') {
-                        fieldDef.items = f.items || { type: 'String' };
+                        if (f.items && typeof f.items === 'object') {
+                            const itemDef = { type: f.items.type || 'String' };
+                            if (f.items.type === 'Ref') {
+                                itemDef.ref = f.items.ref || 'users';
+                            } else if (f.items.type === 'Object' && Array.isArray(f.items.fields) && f.items.fields.length > 0) {
+                                itemDef.fields = sanitizeFields(f.items.fields);
+                            }
+                            fieldDef.items = itemDef;
+                        } else {
+                            fieldDef.items = { type: typeof f.items === 'string' ? f.items : 'String' };
+                        }
                     } else if (f.type === 'Object' && Array.isArray(f.fields) && f.fields.length > 0) {
                         fieldDef.fields = sanitizeFields(f.fields);
                     }
@@ -294,12 +332,8 @@ const collectionCreator = async (req, res, next) => {
                 .filter(c => c.fields.length > 0);
         }
 
-        // 7. Save session & counter with TTL
+        // 7. Save session with TTL
         session.messages.push({ role: "assistant", content: aiResponse.message });
-        if (!hasByok) {
-           iterations += 1;
-           await redis.set(iterKey, iterations.toString(), 'EX', 7200);
-        }
         await redis.set(sessionKey, JSON.stringify(session), 'EX', 7200);
 
         return new ApiResponse({
@@ -311,6 +345,14 @@ const collectionCreator = async (req, res, next) => {
         }, "Agent responded successfully").send(res);
 
     } catch (error) {
+        // Rollback reserved iteration on error if platform key was used
+        if (!hasByok && reservedIteration && iterKey) {
+            try {
+                await redis.decr(iterKey);
+            } catch (revertErr) {
+                console.warn("[CollectionCreator] Failed to rollback reserved iteration counter", revertErr);
+            }
+        }
         if (error instanceof AppError) {
             return next(error);
         }

--- a/apps/python-service/routers/ai.py
+++ b/apps/python-service/routers/ai.py
@@ -49,6 +49,13 @@ class CollectionField(BaseModel):
     items: dict | None = None
     fields: list["CollectionField"] | None = None
 
+    @model_validator(mode='after')
+    def validate_object_fields(self):
+        if self.type == "Object":
+            if self.fields is None or len(self.fields) == 0:
+                raise ValueError("fields must be present and non-empty for Object type")
+        return self
+
 class CollectionSchema(BaseModel):
     collection: str
     fields: list[CollectionField]

--- a/apps/python-service/routers/ai.py
+++ b/apps/python-service/routers/ai.py
@@ -45,6 +45,9 @@ class CollectionField(BaseModel):
     type: str
     required: bool = False
     ref: str | None = None
+    unique: bool = False
+    items: dict | None = None
+    fields: list["CollectionField"] | None = None
 
 class CollectionSchema(BaseModel):
     collection: str
@@ -171,7 +174,7 @@ async def collection_creator(request: CollectionCreatorRequest, req: Request):
 Rules:
 1. If the description is vague, ask 2-3 specific clarifying questions and set type: "clarify". You MUST set "schema": null. NEVER ask more than 3 at once.
 2. Once you have enough context, propose a schema and set type: "schema".
-3. Only use these field types: String, Number, Boolean, Date, Ref, Array. (For Ref, ALWAYS set 'ref' to the referenced collection name e.g. 'users'. Avoid empty Object types).
+3. Only use these field types: String, Number, Boolean, Date, Ref, Array, Object. For Ref, ALWAYS set 'ref' to the referenced collection name e.g. 'users'. For Array, set 'items' to describe item type e.g. {"type": "String"}. For Object, set 'fields' as a list of sub-fields. Do NOT use Object as a lazy catch-all — prefer specific flat fields when possible.
 4. ALWAYS include "createdAt" (type: Date, required: true) in EVERY collection.
 5. Suggest Ref to "users" where ownership applies (ownerId, authorId, userId, etc.) with 'ref': 'users'.
 6. NEVER generate a collection named "users" — it is reserved for auth.

--- a/apps/python-service/tests/test_byok.py
+++ b/apps/python-service/tests/test_byok.py
@@ -46,7 +46,7 @@ async def test_byok_key_decrypted_and_used(mock_decrypt):
         mock_decrypt.assert_called_once_with(encrypted_byok["groqKey"])
         MockGroq.assert_called_once_with(
             api_key="gsk_test_byok_key_12345",
-            model_name="llama-3.1-8b-instant",
+            model_name="llama-3.3-70b-versatile",
             temperature=0,
         )
 
@@ -73,7 +73,7 @@ async def test_free_tier_under_limit(mock_redis):
 
         MockGroq.assert_called_once_with(
             api_key=settings.GROQ_API_KEY,
-            model_name="llama-3.1-8b-instant",
+            model_name="llama-3.3-70b-versatile",
             temperature=0,
         )
 
@@ -100,7 +100,7 @@ async def test_pro_tier_under_limit(mock_redis):
 
         MockGroq.assert_called_with(
             api_key=settings.GROQ_API_KEY,
-            model_name="llama-3.1-8b-instant",
+            model_name="llama-3.3-70b-versatile",
             temperature=0,
         )
 
@@ -111,7 +111,7 @@ async def test_pro_tier_under_limit(mock_redis):
         client = await resolve_ai_client("dev123", "pro", None)
         MockGroq.assert_called_with(
             api_key=settings.GROQ_API_KEY,
-            model_name="llama-3.1-8b-instant",
+            model_name="llama-3.3-70b-versatile",
             temperature=0,
         )
 

--- a/apps/python-service/tests/test_collection_creator.py
+++ b/apps/python-service/tests/test_collection_creator.py
@@ -46,8 +46,8 @@ async def test_collection_creator_schema_validation_rejection():
             headers={"X-Internal-Signature": "fake_sig"}
         )
         
-        # Pydantic validation errors from Langchain result in an unhandled exception (500)
-        assert response.status_code == 500
+        # Pydantic validation errors from Langchain result in 400 Bad Request
+        assert response.status_code == 400
 
 @pytest.mark.asyncio
 async def test_collection_creator_success():

--- a/apps/python-service/tests/test_collection_creator.py
+++ b/apps/python-service/tests/test_collection_creator.py
@@ -126,3 +126,39 @@ async def test_collection_creator_timeout():
             )
             
             assert response.status_code == 504
+
+def test_collection_field_object_validation():
+    from routers.ai import CollectionField
+    from pydantic import ValidationError
+
+    # 1. Reject missing fields on Object
+    with pytest.raises(ValidationError) as exc:
+        CollectionField(name="profile", type="Object")
+    assert "fields must be present and non-empty for Object type" in str(exc.value)
+
+    # 2. Reject None fields on Object
+    with pytest.raises(ValidationError) as exc:
+        CollectionField(name="profile", type="Object", fields=None)
+    assert "fields must be present and non-empty for Object type" in str(exc.value)
+
+    # 3. Reject empty fields list on Object
+    with pytest.raises(ValidationError) as exc:
+        CollectionField(name="profile", type="Object", fields=[])
+    assert "fields must be present and non-empty for Object type" in str(exc.value)
+
+    # 4. Valid Object with non-empty fields
+    valid_field = CollectionField(
+        name="profile",
+        type="Object",
+        fields=[CollectionField(name="bio", type="String", required=True)]
+    )
+    assert valid_field.name == "profile"
+    assert valid_field.type == "Object"
+    assert len(valid_field.fields) == 1
+    assert valid_field.fields[0].name == "bio"
+
+    # 5. Non-Object fields do not require fields
+    valid_string = CollectionField(name="title", type="String")
+    assert valid_string.name == "title"
+    assert valid_string.fields is None
+

--- a/apps/web-dashboard/src/components/CollectionCreatorAgent.jsx
+++ b/apps/web-dashboard/src/components/CollectionCreatorAgent.jsx
@@ -1,15 +1,29 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import api from '../utils/api';
 import { toast } from 'react-hot-toast';
-import { Send, Sparkles } from 'lucide-react';
+import { Send, Sparkles, RotateCcw, ArrowRight } from 'lucide-react';
+
+const SUGGESTIONS = [
+  { label: '🛒 E-commerce store', prompt: 'Create an e-commerce platform with products, categories, orders, and customer reviews' },
+  { label: '📋 Project management', prompt: 'Build a project management tool with workspaces, tasks, milestones, and time tracking' },
+  { label: '📝 Blog platform', prompt: 'Design a blog with posts, authors, tags, comments, and draft management' },
+  { label: '🎓 Learning platform', prompt: 'Create a learning platform with courses, modules, lessons, quizzes, and student enrollments' },
+];
+
+const createMsg = (role, content) => ({
+  id: `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+  role,
+  content
+});
 
 export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
   const [messages, setMessages] = useState([
-    { role: 'assistant', content: "Hi! Tell me what you're building — for example: 'a food delivery app' or 'a SaaS project management tool' — and I'll design a MongoDB schema for you." }
+    createMsg('assistant', "Hi! Tell me what you're building — for example: 'a food delivery app' or 'a SaaS project management tool' — and I'll design a MongoDB schema for you.")
   ]);
   const [aiStatus, setAiStatus] = useState('idle'); // 'idle' | 'loading' | 'error'
   const [schema, setSchema] = useState(null);
   const [iterationsLeft, setIterationsLeft] = useState(null);
+  const [iterationLimit, setIterationLimit] = useState(null);
   const [inputValue, setInputValue] = useState('');
   const [isInserting, setIsInserting] = useState(false);
   const [insertResults, setInsertResults] = useState(null);
@@ -37,31 +51,31 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
   useEffect(() => {
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
-      textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 120)}px`;
+      textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 130)}px`;
     }
   }, [inputValue]);
 
-  const sendMessage = async (e) => {
+  const sendMessage = useCallback(async (e, overrideText) => {
     if (e) e.preventDefault();
-    if (!inputValue.trim() || aiStatus === 'loading' || iterationsLeft === 0) return;
+    const textToSend = (overrideText || inputValue).trim();
+    if (!textToSend || aiStatus === 'loading' || iterationsLeft === 0) return;
     
-    const userText = inputValue.trim();
     setInputValue('');
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
     }
-    setMessages(prev => [...prev, { role: 'user', content: userText }]);
+    setMessages(prev => [...prev, createMsg('user', textToSend)]);
     setAiStatus('loading');
     setInsertResults(null);
     
     try {
       const res = await api.post(`/api/projects/${projectId}/ai/collection-creator`, {
-        userMessage: userText
+        userMessage: textToSend
       });
       
-      const { message, schema: newSchema, iterationsLeft: left } = res.data.data;
+      const { message, schema: newSchema, iterationsLeft: left, iterationLimit: limit } = res.data.data;
       
-      setMessages(prev => [...prev, { role: 'assistant', content: message }]);
+      setMessages(prev => [...prev, createMsg('assistant', message)]);
       
       if (newSchema?.length) {
         setSchema(newSchema);
@@ -70,18 +84,38 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
       if (left !== undefined) {
         setIterationsLeft(left);
       }
+      if (limit !== undefined) {
+        setIterationLimit(limit);
+      }
       setAiStatus('idle');
     } catch (err) {
       const detail = err.response?.data?.message || err.response?.data?.error || "AI request failed. Please try again.";
       setAiStatus('error');
       toast.error(detail);
       
-      // Automatically clear the error status after a short delay so they can type again
       const timer = setTimeout(() => {
           setAiStatus(prev => prev === 'error' ? 'idle' : prev);
       }, 2000);
       timersRef.current.push(timer);
     }
+  }, [inputValue, aiStatus, iterationsLeft, projectId]);
+
+  const handleResetChat = async () => {
+    if (aiStatus === 'loading') return;
+    try {
+      await api.delete(`/api/projects/${projectId}/ai/collection-creator/session`);
+    } catch (e) {
+      console.warn("Failed to delete session on server", e);
+    }
+    setMessages([
+      createMsg('assistant', "Hi! Tell me what you're building — for example: 'a food delivery app' or 'a SaaS project management tool' — and I'll design a MongoDB schema for you.")
+    ]);
+    setSchema(null);
+    setInsertResults(null);
+    setIterationsLeft(null);
+    setIterationLimit(null);
+    setInputValue('');
+    toast.success("Chat reset");
   };
 
   const handleKeyDown = (e) => {
@@ -92,6 +126,10 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
   };
 
   const handleInsertAll = async () => {
+    if (!schema || schema.length === 0) return;
+    const confirmed = window.confirm(`Are you sure you want to create ${schema.length} collection(s) in your database?`);
+    if (!confirmed) return;
+
     setIsInserting(true);
     setInsertResults(null);
     try {
@@ -135,13 +173,12 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
 
       if (failed === 0) {
         toast.success(`${created} collection(s) created successfully!`);
-        timersRef.current.push(setTimeout(() => onInsertAll(), 1500));
       } else {
         toast.error(`${failed} collection(s) failed. ${created} created successfully.`);
-        timersRef.current.push(setTimeout(() => onInsertAll(), 4000));
       }
     } catch (err) {
       toast.error(err.response?.data?.message || err.response?.data?.error || "Bulk insert failed");
+    } finally {
       setIsInserting(false);
     }
   };
@@ -149,12 +186,13 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
   const getIterationsBadge = () => {
     if (iterationsLeft === null) return null; // BYOK
     
-    const used = 3 - iterationsLeft;
-    const dots = Array(3).fill(0).map((_, i) => i < used ? '●' : '○').join('');
+    const limit = iterationLimit || 3;
+    const used = Math.max(0, limit - iterationsLeft);
+    const dots = Array(limit).fill(0).map((_, i) => i < used ? '●' : '○').join('');
     
     return (
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: '8px', padding: '0 4px', fontSize: '0.75rem', color: 'var(--color-text-muted)' }}>
-        <span>{used} of 3 AI turns used <span style={{ marginLeft: '6px', letterSpacing: '0.1em' }}>{dots}</span></span>
+        <span>{used} of {limit} AI turns used <span style={{ marginLeft: '6px', letterSpacing: '0.1em' }}>{dots}</span></span>
         {iterationsLeft === 0 && <span style={{ color: 'var(--color-danger)', fontWeight: 600 }}>Add Groq API key in Settings for unlimited</span>}
       </div>
     );
@@ -177,8 +215,8 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
             gap: '1.25rem'
           }}
         >
-          {messages.map((msg, idx) => (
-            <div key={idx} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+          {messages.map((msg) => (
+            <div key={msg.id} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
               <div 
                 style={{ 
                   maxWidth: '85%', 
@@ -199,6 +237,46 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
               </div>
             </div>
           ))}
+
+          {/* Quick Start Suggestions on empty chat */}
+          {messages.length <= 1 && !schema && (
+            <div style={{ marginTop: '0.5rem', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              <span style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--color-text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em', paddingLeft: '4px' }}>
+                Quick Start Ideas
+              </span>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '8px' }}>
+                {SUGGESTIONS.map((s, i) => (
+                  <button
+                    key={i}
+                    type="button"
+                    onClick={() => sendMessage(null, s.prompt)}
+                    disabled={aiStatus === 'loading'}
+                    style={{
+                      textAlign: 'left',
+                      padding: '10px 14px',
+                      backgroundColor: 'var(--color-bg-card)',
+                      border: '1px solid var(--color-border)',
+                      borderRadius: '12px',
+                      fontSize: '0.825rem',
+                      color: 'var(--color-text-main)',
+                      cursor: 'pointer',
+                      transition: 'all 0.2s ease',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: '8px'
+                    }}
+                    onMouseEnter={(e) => { e.currentTarget.style.borderColor = 'var(--color-primary)'; e.currentTarget.style.transform = 'translateY(-1px)'; }}
+                    onMouseLeave={(e) => { e.currentTarget.style.borderColor = 'var(--color-border)'; e.currentTarget.style.transform = 'translateY(0)'; }}
+                  >
+                    <span>{s.label}</span>
+                    <ArrowRight size={13} style={{ opacity: 0.6, flexShrink: 0 }} />
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
           {aiStatus === 'loading' && (
             <div className="flex justify-start">
               <div 
@@ -300,9 +378,23 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
         }}
       >
         <div style={{ padding: '1.1rem 1.5rem', borderBottom: '1px solid var(--color-border)', backgroundColor: 'var(--color-bg-card)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexShrink: 0 }}>
-          <h3 style={{ fontSize: '0.95rem', fontWeight: 600, color: 'var(--color-text-main)', display: 'flex', alignItems: 'center', gap: '8px', margin: 0 }}>
-            <Sparkles size={16} style={{ color: 'var(--color-primary)' }} /> Schema Preview
-          </h3>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <h3 style={{ fontSize: '0.95rem', fontWeight: 600, color: 'var(--color-text-main)', display: 'flex', alignItems: 'center', gap: '8px', margin: 0 }}>
+              <Sparkles size={16} style={{ color: 'var(--color-primary)' }} /> Schema Preview
+            </h3>
+            {messages.length > 1 && (
+              <button
+                type="button"
+                onClick={handleResetChat}
+                className="btn btn-ghost"
+                style={{ padding: '4px 8px', fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '4px', color: 'var(--color-text-muted)', borderRadius: '6px' }}
+                title="Reset conversation"
+              >
+                <RotateCcw size={12} /> New Chat
+              </button>
+            )}
+          </div>
+
           {schema && schema.length > 0 && (
             <button
               onClick={handleInsertAll}
@@ -329,13 +421,23 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
                 </svg>
               </div>
               <p style={{ fontSize: '0.9rem', color: 'var(--color-text-main)', fontWeight: 500, margin: 0 }}>Your generated schema will appear here.</p>
-              <p style={{ fontSize: '0.8rem', opacity: 0.8, marginTop: '6px', margin: 0 }}>Start by chatting with the AI.</p>
+              <p style={{ fontSize: '0.8rem', opacity: 0.8, marginTop: '6px', margin: 0 }}>Start by chatting with the AI or clicking a suggestion above.</p>
             </div>
           ) : (
             <div className="space-y-6">
               {insertResults && (
                 <div style={{ padding: '1.25rem', backgroundColor: 'var(--color-bg-input)', border: '1px solid var(--color-border)', borderRadius: '10px', animation: 'fadeIn 0.3s ease-out' }}>
-                  <p style={{ fontSize: '0.85rem', fontWeight: 600, color: 'var(--color-text-main)', marginBottom: '12px' }}>Insert Results</p>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
+                    <p style={{ fontSize: '0.85rem', fontWeight: 600, color: 'var(--color-text-main)', margin: 0 }}>Insert Results</p>
+                    <button
+                      type="button"
+                      onClick={() => onInsertAll && onInsertAll()}
+                      className="btn btn-primary"
+                      style={{ padding: '4px 12px', fontSize: '0.75rem', borderRadius: '6px', display: 'flex', alignItems: 'center', gap: '4px' }}
+                    >
+                      Continue to Database <ArrowRight size={12} />
+                    </button>
+                  </div>
                   <ul className="space-y-3">
                     {insertResults.map((r, i) => (
                       <li key={i} style={{ display: 'flex', alignItems: 'start', gap: '10px', fontSize: '0.8rem', color: r.success ? 'var(--color-success)' : 'var(--color-danger)' }}>
@@ -361,7 +463,18 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
                       <tbody style={{ display: 'block', width: '100%' }}>
                         {col.fields?.map((f, i) => (
                           <tr key={i} style={{ display: 'flex', width: '100%', borderBottom: i < col.fields.length - 1 ? '1px solid var(--color-border)' : 'none' }}>
-                            <td style={{ padding: '12px 18px', fontFamily: 'monospace', color: 'var(--color-text-main)', width: '50%', borderRight: '1px solid var(--color-border)' }}>{f.name}</td>
+                            <td style={{ padding: '12px 18px', fontFamily: 'monospace', color: 'var(--color-text-main)', width: '50%', borderRight: '1px solid var(--color-border)' }}>
+                              {f.name}
+                              {f.fields && f.fields.length > 0 && (
+                                <div style={{ marginTop: '6px', paddingLeft: '12px', borderLeft: '2px solid rgba(62,207,142,0.3)', fontSize: '0.75rem', color: 'var(--color-text-muted)' }}>
+                                  {f.fields.map((sub, sIdx) => (
+                                    <div key={sIdx} style={{ padding: '2px 0' }}>
+                                      <code>{sub.name}</code>: <span style={{ opacity: 0.8 }}>{sub.type}</span>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                            </td>
                             <td style={{ padding: '12px 18px', color: 'var(--color-text-muted)', width: '50%', display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
                               <span className="badge" style={{ 
                                 backgroundColor: 'var(--color-bg-card)', 
@@ -371,10 +484,13 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
                                 padding: '3px 8px',
                                 borderRadius: '4px'
                               }}>
-                                {f.type}
+                                {f.type === 'Array' && f.items?.type ? `Array<${f.items.type}>` : f.type}
                               </span>
                               {f.type === 'Ref' && f.ref && (
                                 <span style={{ fontSize: '0.7rem', color: 'var(--color-primary)', fontWeight: 500 }}>→ {f.ref}</span>
+                              )}
+                              {f.unique && (
+                                <span style={{ fontSize: '0.65rem', color: 'var(--color-primary)', border: '1px solid var(--color-primary)', padding: '1px 5px', borderRadius: '3px', fontWeight: 600 }}>UNIQUE</span>
                               )}
                               {f.required && (
                                 <span style={{ color: 'var(--color-danger)', marginLeft: 'auto', fontWeight: 700, fontSize: '0.9rem' }} title="Required">*</span>

--- a/apps/web-dashboard/src/components/CollectionCreatorAgent.jsx
+++ b/apps/web-dashboard/src/components/CollectionCreatorAgent.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import api from '../utils/api';
 import { toast } from 'react-hot-toast';
-import { Send, Sparkles, RotateCcw, ArrowRight } from 'lucide-react';
+import { Send, ArrowRight } from 'lucide-react';
 import SchemaCanvasViewer from './SchemaCanvasViewer';
 
 const SUGGESTIONS = [
@@ -105,18 +105,20 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
     if (aiStatus === 'loading') return;
     try {
       await api.delete(`/api/projects/${projectId}/ai/collection-creator/session`);
+      setMessages([
+        createMsg('assistant', "Hi! Tell me what you're building — for example: 'a food delivery app' or 'a SaaS project management tool' — and I'll design a MongoDB schema for you.")
+      ]);
+      setSchema(null);
+      setInsertResults(null);
+      setIterationsLeft(null);
+      setIterationLimit(null);
+      setInputValue('');
+      toast.success("Chat reset");
     } catch (e) {
-      console.warn("Failed to delete session on server", e);
+      console.error("Failed to delete session on server", e);
+      const detail = e.response?.data?.message || e.response?.data?.error || "Failed to reset chat session. Please try again.";
+      toast.error(detail);
     }
-    setMessages([
-      createMsg('assistant', "Hi! Tell me what you're building — for example: 'a food delivery app' or 'a SaaS project management tool' — and I'll design a MongoDB schema for you.")
-    ]);
-    setSchema(null);
-    setInsertResults(null);
-    setIterationsLeft(null);
-    setIterationLimit(null);
-    setInputValue('');
-    toast.success("Chat reset");
   };
 
   const handleKeyDown = (e) => {
@@ -138,12 +140,24 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
         if (!fields) return [];
         return fields.map(f => {
           const fieldDef = {
-            key: f.name,
+            key: f.name || f.key,
             type: f.type,
             required: !!f.required
           };
           if (f.type === 'Array') {
-            fieldDef.items = f.items ? (typeof f.items === 'object' ? f.items : { type: f.items }) : { type: 'String' };
+            if (f.items && typeof f.items === 'object') {
+              const itemDef = { type: f.items.type || 'String' };
+              if (f.items.type === 'Ref') {
+                itemDef.ref = f.items.ref || 'users';
+              } else if (f.items.type === 'Object') {
+                itemDef.fields = f.items.fields?.length
+                  ? mapSchemaFields(f.items.fields)
+                  : [{ key: 'data', type: 'String', required: false }];
+              }
+              fieldDef.items = itemDef;
+            } else {
+              fieldDef.items = { type: typeof f.items === 'string' ? f.items : 'String' };
+            }
           } else if (f.type === 'Object') {
             fieldDef.fields = f.fields?.length ? mapSchemaFields(f.fields) : [{ key: 'data', type: 'String', required: false }];
           } else if (f.type === 'Ref') {
@@ -251,7 +265,7 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
                     key={i}
                     type="button"
                     onClick={() => sendMessage(null, s.prompt)}
-                    disabled={aiStatus === 'loading'}
+                    disabled={aiStatus === 'loading' || iterationsLeft === 0}
                     style={{
                       textAlign: 'left',
                       padding: '10px 14px',
@@ -260,15 +274,24 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
                       borderRadius: '12px',
                       fontSize: '0.825rem',
                       color: 'var(--color-text-main)',
-                      cursor: 'pointer',
+                      cursor: (aiStatus === 'loading' || iterationsLeft === 0) ? 'not-allowed' : 'pointer',
+                      opacity: (aiStatus === 'loading' || iterationsLeft === 0) ? 0.45 : 1,
                       transition: 'all 0.2s ease',
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'space-between',
                       gap: '8px'
                     }}
-                    onMouseEnter={(e) => { e.currentTarget.style.borderColor = 'var(--color-primary)'; e.currentTarget.style.transform = 'translateY(-1px)'; }}
-                    onMouseLeave={(e) => { e.currentTarget.style.borderColor = 'var(--color-border)'; e.currentTarget.style.transform = 'translateY(0)'; }}
+                    onMouseEnter={(e) => {
+                      if (aiStatus !== 'loading' && iterationsLeft !== 0) {
+                        e.currentTarget.style.borderColor = 'var(--color-primary)';
+                        e.currentTarget.style.transform = 'translateY(-1px)';
+                      }
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.borderColor = 'var(--color-border)';
+                      e.currentTarget.style.transform = 'translateY(0)';
+                    }}
                   >
                     <span>{s.label}</span>
                     <ArrowRight size={13} style={{ opacity: 0.6, flexShrink: 0 }} />
@@ -369,6 +392,7 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
         </div>
       </div>
 
+      {/* Floating Schema Canvas Visualizer Panel - Right */}
       <SchemaCanvasViewer 
         schema={schema}
         messages={messages}

--- a/apps/web-dashboard/src/components/CollectionCreatorAgent.jsx
+++ b/apps/web-dashboard/src/components/CollectionCreatorAgent.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import api from '../utils/api';
 import { toast } from 'react-hot-toast';
 import { Send, Sparkles, RotateCcw, ArrowRight } from 'lucide-react';
+import SchemaCanvasViewer from './SchemaCanvasViewer';
 
 const SUGGESTIONS = [
   { label: '🛒 E-commerce store', prompt: 'Create an e-commerce platform with products, categories, orders, and customer reviews' },
@@ -368,145 +369,15 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
         </div>
       </div>
 
-      {/* Floating Schema Preview Panel - Right */}
-      <div 
-        className="flex flex-col w-full lg:w-[48%] h-full rounded-2xl overflow-hidden shadow-sm transition-all" 
-        style={{ 
-          backgroundColor: 'var(--color-bg-card)', 
-          border: '1px solid var(--color-border)',
-          display: 'flex'
-        }}
-      >
-        <div style={{ padding: '1.1rem 1.5rem', borderBottom: '1px solid var(--color-border)', backgroundColor: 'var(--color-bg-card)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexShrink: 0 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <h3 style={{ fontSize: '0.95rem', fontWeight: 600, color: 'var(--color-text-main)', display: 'flex', alignItems: 'center', gap: '8px', margin: 0 }}>
-              <Sparkles size={16} style={{ color: 'var(--color-primary)' }} /> Schema Preview
-            </h3>
-            {messages.length > 1 && (
-              <button
-                type="button"
-                onClick={handleResetChat}
-                className="btn btn-ghost"
-                style={{ padding: '4px 8px', fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '4px', color: 'var(--color-text-muted)', borderRadius: '6px' }}
-                title="Reset conversation"
-              >
-                <RotateCcw size={12} /> New Chat
-              </button>
-            )}
-          </div>
-
-          {schema && schema.length > 0 && (
-            <button
-              onClick={handleInsertAll}
-              disabled={isInserting}
-              className="btn btn-primary"
-              style={{ opacity: isInserting ? 0.7 : 1, padding: '6px 18px', fontSize: '0.85rem', borderRadius: '8px' }}
-            >
-              {isInserting ? (
-                <>
-                  <div className="spinner-small" style={{ borderColor: 'rgba(0,0,0,0.1)', borderTopColor: '#000', width: '12px', height: '12px' }}></div>
-                  Inserting...
-                </>
-              ) : `✓ Insert All (${schema.length})`}
-            </button>
-          )}
-        </div>
-        
-        <div className="flex-1 overflow-y-auto custom-scrollbar" style={{ padding: '1.5rem', backgroundColor: 'var(--color-bg-card)' }}>
-          {!schema || schema.length === 0 ? (
-            <div className="h-full flex flex-col items-center justify-center text-center transition-all" style={{ color: 'var(--color-text-muted)', minHeight: '300px' }}>
-              <div style={{ padding: '20px', borderRadius: '50%', backgroundColor: 'var(--color-bg-input)', border: '1px solid var(--color-border)', marginBottom: '16px', boxShadow: '0 8px 32px rgba(0,0,0,0.05)' }}>
-                <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 002-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-                </svg>
-              </div>
-              <p style={{ fontSize: '0.9rem', color: 'var(--color-text-main)', fontWeight: 500, margin: 0 }}>Your generated schema will appear here.</p>
-              <p style={{ fontSize: '0.8rem', opacity: 0.8, marginTop: '6px', margin: 0 }}>Start by chatting with the AI or clicking a suggestion above.</p>
-            </div>
-          ) : (
-            <div className="space-y-6">
-              {insertResults && (
-                <div style={{ padding: '1.25rem', backgroundColor: 'var(--color-bg-input)', border: '1px solid var(--color-border)', borderRadius: '10px', animation: 'fadeIn 0.3s ease-out' }}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
-                    <p style={{ fontSize: '0.85rem', fontWeight: 600, color: 'var(--color-text-main)', margin: 0 }}>Insert Results</p>
-                    <button
-                      type="button"
-                      onClick={() => onInsertAll && onInsertAll()}
-                      className="btn btn-primary"
-                      style={{ padding: '4px 12px', fontSize: '0.75rem', borderRadius: '6px', display: 'flex', alignItems: 'center', gap: '4px' }}
-                    >
-                      Continue to Database <ArrowRight size={12} />
-                    </button>
-                  </div>
-                  <ul className="space-y-3">
-                    {insertResults.map((r, i) => (
-                      <li key={i} style={{ display: 'flex', alignItems: 'start', gap: '10px', fontSize: '0.8rem', color: r.success ? 'var(--color-success)' : 'var(--color-danger)' }}>
-                        <span style={{ marginTop: '1px', fontWeight: 700 }}>{r.success ? '✓' : '✗'}</span>
-                        <span style={{ color: 'var(--color-text-main)' }}>
-                          <strong style={{ fontWeight: 600 }}>{r.collection}</strong>
-                          {!r.success && <span style={{ display: 'block', color: 'var(--color-danger)', fontSize: '0.75rem', marginTop: '4px', opacity: 0.9 }}>{r.error}</span>}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              
-              {schema.map((col, idx) => (
-                <div key={idx} style={{ backgroundColor: 'var(--color-bg-input)', border: '1px solid var(--color-border)', borderRadius: '12px', overflow: 'hidden', animation: 'fadeIn 0.4s ease-out' }} className="transition-all hover:border-white/20 shadow-sm">
-                  <div style={{ padding: '12px 18px', borderBottom: '1px solid var(--color-border)', fontSize: '0.85rem', fontWeight: 600, color: 'var(--color-text-main)', fontFamily: 'monospace', display: 'flex', alignItems: 'center' }}>
-                    <span style={{ color: 'var(--color-primary)', marginRight: '10px', fontSize: '1.1rem' }}>⛁</span>
-                    {col.collection}
-                  </div>
-                  <div>
-                    <table style={{ width: '100%', textAlign: 'left', fontSize: '0.8rem', borderCollapse: 'collapse' }}>
-                      <tbody style={{ display: 'block', width: '100%' }}>
-                        {col.fields?.map((f, i) => (
-                          <tr key={i} style={{ display: 'flex', width: '100%', borderBottom: i < col.fields.length - 1 ? '1px solid var(--color-border)' : 'none' }}>
-                            <td style={{ padding: '12px 18px', fontFamily: 'monospace', color: 'var(--color-text-main)', width: '50%', borderRight: '1px solid var(--color-border)' }}>
-                              {f.name}
-                              {f.fields && f.fields.length > 0 && (
-                                <div style={{ marginTop: '6px', paddingLeft: '12px', borderLeft: '2px solid rgba(62,207,142,0.3)', fontSize: '0.75rem', color: 'var(--color-text-muted)' }}>
-                                  {f.fields.map((sub, sIdx) => (
-                                    <div key={sIdx} style={{ padding: '2px 0' }}>
-                                      <code>{sub.name}</code>: <span style={{ opacity: 0.8 }}>{sub.type}</span>
-                                    </div>
-                                  ))}
-                                </div>
-                              )}
-                            </td>
-                            <td style={{ padding: '12px 18px', color: 'var(--color-text-muted)', width: '50%', display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
-                              <span className="badge" style={{ 
-                                backgroundColor: 'var(--color-bg-card)', 
-                                border: '1px solid var(--color-border)',
-                                color: 'var(--color-text-main)',
-                                fontSize: '0.7rem',
-                                padding: '3px 8px',
-                                borderRadius: '4px'
-                              }}>
-                                {f.type === 'Array' && f.items?.type ? `Array<${f.items.type}>` : f.type}
-                              </span>
-                              {f.type === 'Ref' && f.ref && (
-                                <span style={{ fontSize: '0.7rem', color: 'var(--color-primary)', fontWeight: 500 }}>→ {f.ref}</span>
-                              )}
-                              {f.unique && (
-                                <span style={{ fontSize: '0.65rem', color: 'var(--color-primary)', border: '1px solid var(--color-primary)', padding: '1px 5px', borderRadius: '3px', fontWeight: 600 }}>UNIQUE</span>
-                              )}
-                              {f.required && (
-                                <span style={{ color: 'var(--color-danger)', marginLeft: 'auto', fontWeight: 700, fontSize: '0.9rem' }} title="Required">*</span>
-                              )}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
+      <SchemaCanvasViewer 
+        schema={schema}
+        messages={messages}
+        insertResults={insertResults}
+        isInserting={isInserting}
+        onInsertAll={handleInsertAll}
+        onResetChat={handleResetChat}
+        onNavigateToDb={() => onInsertAll && onInsertAll()}
+      />
     </div>
   );
 }

--- a/apps/web-dashboard/src/components/SchemaCanvasViewer.jsx
+++ b/apps/web-dashboard/src/components/SchemaCanvasViewer.jsx
@@ -50,7 +50,6 @@ export default function SchemaCanvasViewer({
 
   // Mouse pan handlers
   const handleMouseDown = (e) => {
-    // Only pan if clicking on canvas background or dragging
     if (e.target.closest('.canvas-node') || e.target.closest('button')) return;
     setIsPanning(true);
     setDragStart({ x: e.clientX - pan.x, y: e.clientY - pan.y });
@@ -116,6 +115,93 @@ export default function SchemaCanvasViewer({
       >
         {displayLabel}
       </span>
+    );
+  };
+
+  /**
+   * Unified recursive field renderer for both Canvas and Table views.
+   * Handles nested Object fields at every depth with consistent styling and badges.
+   */
+  const renderFieldTree = (field, depth = 0, isLast = false, viewType = 'canvas', keyPrefix = '') => {
+    const isTable = viewType === 'list';
+    const indentPadding = isTable ? 18 + depth * 16 : 16 + depth * 14;
+    const nodeKey = `${keyPrefix}_${depth}_${field.name || 'field'}`;
+
+    return (
+      <React.Fragment key={nodeKey}>
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: isTable ? `10px 18px 10px ${indentPadding}px` : `7px 16px 7px ${indentPadding}px`,
+            borderBottom: isTable || !isLast ? '1px solid var(--color-border)' : 'none',
+            fontSize: '0.8rem',
+            borderLeft: depth > 0 ? '2px solid rgba(62, 207, 142, 0.35)' : 'none',
+            backgroundColor: depth > 0 ? 'rgba(255, 255, 255, 0.015)' : 'transparent',
+            transition: 'background-color 0.15s ease'
+          }}
+        >
+          {/* Field Name & Required/Unique Badges */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flex: 1, overflow: 'hidden' }}>
+            <span
+              style={{
+                fontFamily: 'monospace',
+                color: depth > 0 ? 'var(--color-text-muted)' : 'var(--color-text-main)',
+                fontWeight: field.required ? 600 : 400,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis'
+              }}
+            >
+              {field.name}
+            </span>
+            {field.required && (
+              <span style={{ color: 'var(--color-danger)', fontWeight: 700, fontSize: '0.85rem' }} title="Required">*</span>
+            )}
+            {field.unique && (
+              <span style={{ fontSize: '0.6rem', color: 'var(--color-primary)', border: '1px solid var(--color-primary)', padding: '0 3px', borderRadius: '2px', fontWeight: 700 }}>U</span>
+            )}
+          </div>
+
+          {/* Type Badge & Ref Links */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            {renderTypeBadge(field)}
+            {field.type === 'Ref' && field.ref && (
+              <span
+                onMouseEnter={() => setHoveredRef(field.ref)}
+                onMouseLeave={() => setHoveredRef(null)}
+                style={{
+                  fontSize: '0.7rem',
+                  color: 'var(--color-primary)',
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '2px'
+                }}
+                title={`References collection '${field.ref}'`}
+              >
+                → {field.ref}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Recurse through nested Object fields at every depth */}
+        {field.fields && field.fields.length > 0 && (
+          field.fields.map((subField, subIdx) => 
+            renderFieldTree(
+              subField, 
+              depth + 1, 
+              isLast && subIdx === field.fields.length - 1, 
+              viewType,
+              `${nodeKey}_${subIdx}`
+            )
+          )
+        )}
+      </React.Fragment>
     );
   };
 
@@ -456,65 +542,10 @@ export default function SchemaCanvasViewer({
                       </span>
                     </div>
 
-                    {/* Explicit Collection Fields */}
-                    {col.fields?.map((f, fIdx) => (
-                      <div 
-                        key={fIdx}
-                        style={{ 
-                          display: 'flex', 
-                          alignItems: 'center', 
-                          justifyContent: 'space-between',
-                          padding: '7px 16px',
-                          borderBottom: fIdx < col.fields.length - 1 ? '1px solid rgba(255, 255, 255, 0.04)' : 'none',
-                          fontSize: '0.8rem'
-                        }}
-                      >
-                        {/* Field Name + Indicators */}
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flex: 1, overflow: 'hidden' }}>
-                          <span 
-                            style={{ 
-                              fontFamily: 'monospace', 
-                              color: 'var(--color-text-main)',
-                              fontWeight: f.required ? 500 : 400,
-                              whiteSpace: 'nowrap',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis'
-                            }}
-                          >
-                            {f.name}
-                          </span>
-                          {f.required && (
-                            <span style={{ color: 'var(--color-danger)', fontWeight: 700, fontSize: '0.85rem' }} title="Required">*</span>
-                          )}
-                          {f.unique && (
-                            <span style={{ fontSize: '0.6rem', color: 'var(--color-primary)', border: '1px solid var(--color-primary)', padding: '0 3px', borderRadius: '2px', fontWeight: 700 }}>U</span>
-                          )}
-                        </div>
-
-                        {/* Field Type Badge & Ref Link */}
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                          {renderTypeBadge(f)}
-                          {f.type === 'Ref' && f.ref && (
-                            <span
-                              onMouseEnter={() => setHoveredRef(f.ref)}
-                              onMouseLeave={() => setHoveredRef(null)}
-                              style={{
-                                fontSize: '0.7rem',
-                                color: 'var(--color-primary)',
-                                fontWeight: 600,
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '2px'
-                              }}
-                              title={`References collection '${f.ref}'`}
-                            >
-                              → {f.ref}
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    ))}
+                    {/* Explicit Collection Fields (Recursive) */}
+                    {col.fields?.map((f, fIdx) => 
+                      renderFieldTree(f, 0, fIdx === col.fields.length - 1, 'canvas', `canvas_${col.collection}_${fIdx}`)
+                    )}
                   </div>
                 </div>
               );
@@ -559,38 +590,46 @@ export default function SchemaCanvasViewer({
                   {col.collection}
                 </div>
                 <div>
-                  <table style={{ width: '100%', textAlign: 'left', fontSize: '0.8rem', borderCollapse: 'collapse' }}>
-                    <tbody style={{ display: 'block', width: '100%' }}>
-                      {col.fields?.map((f, i) => (
-                        <tr key={i} style={{ display: 'flex', width: '100%', borderBottom: i < col.fields.length - 1 ? '1px solid var(--color-border)' : 'none' }}>
-                          <td style={{ padding: '12px 18px', fontFamily: 'monospace', color: 'var(--color-text-main)', width: '50%', borderRight: '1px solid var(--color-border)' }}>
-                            {f.name}
-                            {f.fields && f.fields.length > 0 && (
-                              <div style={{ marginTop: '6px', paddingLeft: '12px', borderLeft: '2px solid rgba(62,207,142,0.3)', fontSize: '0.75rem', color: 'var(--color-text-muted)' }}>
-                                {f.fields.map((sub, sIdx) => (
-                                  <div key={sIdx} style={{ padding: '2px 0' }}>
-                                    <code>{sub.name}</code>: <span style={{ opacity: 0.8 }}>{sub.type}</span>
-                                  </div>
-                                ))}
-                              </div>
-                            )}
-                          </td>
-                          <td style={{ padding: '12px 18px', color: 'var(--color-text-muted)', width: '50%', display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
-                            {renderTypeBadge(f)}
-                            {f.type === 'Ref' && f.ref && (
-                              <span style={{ fontSize: '0.7rem', color: 'var(--color-primary)', fontWeight: 500 }}>→ {f.ref}</span>
-                            )}
-                            {f.unique && (
-                              <span style={{ fontSize: '0.65rem', color: 'var(--color-primary)', border: '1px solid var(--color-primary)', padding: '1px 5px', borderRadius: '3px', fontWeight: 600 }}>UNIQUE</span>
-                            )}
-                            {f.required && (
-                              <span style={{ color: 'var(--color-danger)', marginLeft: 'auto', fontWeight: 700, fontSize: '0.9rem' }} title="Required">*</span>
-                            )}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                  <div style={{ width: '100%' }}>
+                    {/* Implicit _id Primary Key */}
+                    <div 
+                      style={{ 
+                        display: 'flex', 
+                        width: '100%',
+                        alignItems: 'center', 
+                        justifyContent: 'space-between',
+                        padding: '10px 18px',
+                        borderBottom: '1px solid var(--color-border)',
+                        fontSize: '0.8rem'
+                      }}
+                    >
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                        <Key size={11} style={{ color: '#fbbf24' }} title="Primary Key" />
+                        <span style={{ fontFamily: 'monospace', color: 'var(--color-text-main)', fontWeight: 600 }}>
+                          _id
+                        </span>
+                      </div>
+                      <span
+                        style={{
+                          backgroundColor: 'rgba(251, 191, 36, 0.12)',
+                          color: '#fbbf24',
+                          border: '1px solid rgba(251, 191, 36, 0.25)',
+                          borderRadius: '4px',
+                          padding: '1px 6px',
+                          fontSize: '0.65rem',
+                          fontFamily: 'monospace',
+                          fontWeight: 600
+                        }}
+                      >
+                        ObjectId
+                      </span>
+                    </div>
+
+                    {/* Explicit Collection Fields (Recursive) */}
+                    {col.fields?.map((f, fIdx) => 
+                      renderFieldTree(f, 0, fIdx === col.fields.length - 1, 'list', `list_${col.collection}_${fIdx}`)
+                    )}
+                  </div>
                 </div>
               </div>
             ))}

--- a/apps/web-dashboard/src/components/SchemaCanvasViewer.jsx
+++ b/apps/web-dashboard/src/components/SchemaCanvasViewer.jsx
@@ -1,0 +1,602 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { 
+  Sparkles, 
+  RotateCcw, 
+  ZoomIn, 
+  ZoomOut, 
+  Maximize2, 
+  LayoutGrid, 
+  List, 
+  Key, 
+  ArrowRight,
+  Database
+} from 'lucide-react';
+
+const TYPE_COLORS = {
+  String: { bg: 'rgba(59, 130, 246, 0.12)', text: '#60a5fa', border: 'rgba(59, 130, 246, 0.25)' },
+  Number: { bg: 'rgba(245, 158, 11, 0.12)', text: '#fbbf24', border: 'rgba(245, 158, 11, 0.25)' },
+  Boolean: { bg: 'rgba(20, 184, 166, 0.12)', text: '#2dd4bf', border: 'rgba(20, 184, 166, 0.25)' },
+  Date: { bg: 'rgba(168, 85, 247, 0.12)', text: '#c084fc', border: 'rgba(168, 85, 247, 0.25)' },
+  Ref: { bg: 'rgba(16, 185, 129, 0.15)', text: '#34d399', border: 'rgba(16, 185, 129, 0.3)' },
+  Array: { bg: 'rgba(14, 165, 233, 0.12)', text: '#38bdf8', border: 'rgba(14, 165, 233, 0.25)' },
+  Object: { bg: 'rgba(99, 102, 241, 0.12)', text: '#818cf8', border: 'rgba(99, 102, 241, 0.25)' },
+};
+
+export default function SchemaCanvasViewer({
+  schema,
+  messages,
+  insertResults,
+  isInserting,
+  onInsertAll,
+  onResetChat,
+  onNavigateToDb
+}) {
+  const [viewMode, setViewMode] = useState('canvas'); // 'canvas' | 'list'
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 30, y: 30 });
+  const [isPanning, setIsPanning] = useState(false);
+  const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
+  const [hoveredRef, setHoveredRef] = useState(null);
+  
+  const containerRef = useRef(null);
+
+  // Zoom controls
+  const handleZoomIn = () => setZoom(z => Math.min(1.6, Math.round((z + 0.15) * 100) / 100));
+  const handleZoomOut = () => setZoom(z => Math.max(0.45, Math.round((z - 0.15) * 100) / 100));
+  const handleResetView = () => {
+    setZoom(1);
+    setPan({ x: 30, y: 30 });
+  };
+
+  // Mouse pan handlers
+  const handleMouseDown = (e) => {
+    // Only pan if clicking on canvas background or dragging
+    if (e.target.closest('.canvas-node') || e.target.closest('button')) return;
+    setIsPanning(true);
+    setDragStart({ x: e.clientX - pan.x, y: e.clientY - pan.y });
+  };
+
+  const handleMouseMove = useCallback((e) => {
+    if (!isPanning) return;
+    setPan({
+      x: e.clientX - dragStart.x,
+      y: e.clientY - dragStart.y
+    });
+  }, [isPanning, dragStart]);
+
+  const handleMouseUp = useCallback(() => {
+    setIsPanning(false);
+  }, []);
+
+  useEffect(() => {
+    if (isPanning) {
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+      return () => {
+        window.removeEventListener('mousemove', handleMouseMove);
+        window.removeEventListener('mouseup', handleMouseUp);
+      };
+    }
+  }, [isPanning, handleMouseMove, handleMouseUp]);
+
+  // Wheel zoom handler
+  const handleWheel = (e) => {
+    if (e.ctrlKey || e.metaKey) {
+      e.preventDefault();
+      const delta = e.deltaY < 0 ? 0.1 : -0.1;
+      setZoom(z => Math.min(1.6, Math.max(0.45, Math.round((z + delta) * 100) / 100)));
+    }
+  };
+
+  const renderTypeBadge = (field) => {
+    const typeKey = field.type || 'String';
+    const styling = TYPE_COLORS[typeKey] || TYPE_COLORS.String;
+
+    let displayLabel = field.type;
+    if (field.type === 'Array' && field.items?.type) {
+      displayLabel = `Array<${field.items.type}>`;
+    }
+
+    return (
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '4px',
+          backgroundColor: styling.bg,
+          color: styling.text,
+          border: `1px solid ${styling.border}`,
+          borderRadius: '5px',
+          padding: '2px 7px',
+          fontSize: '0.7rem',
+          fontWeight: 500,
+          letterSpacing: '0.02em',
+          fontFamily: 'monospace'
+        }}
+      >
+        {displayLabel}
+      </span>
+    );
+  };
+
+  return (
+    <div 
+      className="flex flex-col w-full lg:w-[48%] h-full rounded-2xl overflow-hidden shadow-sm transition-all" 
+      style={{ 
+        backgroundColor: 'var(--color-bg-card)', 
+        border: '1px solid var(--color-border)',
+        display: 'flex',
+        position: 'relative'
+      }}
+    >
+      {/* Top Header & Toolbar */}
+      <div 
+        style={{ 
+          padding: '0.85rem 1.25rem', 
+          borderBottom: '1px solid var(--color-border)', 
+          backgroundColor: 'var(--color-bg-card)', 
+          display: 'flex', 
+          justifyContent: 'space-between', 
+          alignItems: 'center', 
+          flexShrink: 0,
+          gap: '12px',
+          flexWrap: 'wrap',
+          zIndex: 10
+        }}
+      >
+        {/* Left: Title & Mode Toggle */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <h3 style={{ fontSize: '0.925rem', fontWeight: 600, color: 'var(--color-text-main)', display: 'flex', alignItems: 'center', gap: '7px', margin: 0 }}>
+            <Sparkles size={15} style={{ color: 'var(--color-primary)' }} /> Schema Visualizer
+          </h3>
+          
+          {schema && schema.length > 0 && (
+            <div style={{ display: 'inline-flex', padding: '2px', background: 'var(--color-bg-input)', borderRadius: '8px', border: '1px solid var(--color-border)' }}>
+              <button
+                type="button"
+                onClick={() => setViewMode('canvas')}
+                style={{
+                  padding: '4px 10px',
+                  fontSize: '0.75rem',
+                  fontWeight: 500,
+                  borderRadius: '6px',
+                  border: 'none',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                  backgroundColor: viewMode === 'canvas' ? 'var(--color-primary)' : 'transparent',
+                  color: viewMode === 'canvas' ? '#000' : 'var(--color-text-muted)',
+                  transition: 'all 0.15s ease'
+                }}
+                title="Canvas ERD Graph"
+              >
+                <LayoutGrid size={12} /> Canvas
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode('list')}
+                style={{
+                  padding: '4px 10px',
+                  fontSize: '0.75rem',
+                  fontWeight: 500,
+                  borderRadius: '6px',
+                  border: 'none',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                  backgroundColor: viewMode === 'list' ? 'var(--color-primary)' : 'transparent',
+                  color: viewMode === 'list' ? '#000' : 'var(--color-text-muted)',
+                  transition: 'all 0.15s ease'
+                }}
+                title="Table List View"
+              >
+                <List size={12} /> Table
+              </button>
+            </div>
+          )}
+
+          {messages.length > 1 && (
+            <button
+              type="button"
+              onClick={onResetChat}
+              className="btn btn-ghost"
+              style={{ padding: '3px 8px', fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '4px', color: 'var(--color-text-muted)', borderRadius: '6px' }}
+              title="Reset conversation"
+            >
+              <RotateCcw size={12} /> New Chat
+            </button>
+          )}
+        </div>
+
+        {/* Right: Actions */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          {schema && schema.length > 0 && (
+            <button
+              onClick={onInsertAll}
+              disabled={isInserting}
+              className="btn btn-primary"
+              style={{ opacity: isInserting ? 0.7 : 1, padding: '5px 16px', fontSize: '0.825rem', borderRadius: '8px', fontWeight: 600 }}
+            >
+              {isInserting ? (
+                <>
+                  <div className="spinner-small" style={{ borderColor: 'rgba(0,0,0,0.1)', borderTopColor: '#000', width: '12px', height: '12px' }}></div>
+                  Inserting...
+                </>
+              ) : `✓ Insert All (${schema.length})`}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Main Content Area */}
+      {!schema || schema.length === 0 ? (
+        <div 
+          className="flex-1 flex flex-col items-center justify-center text-center transition-all" 
+          style={{ 
+            color: 'var(--color-text-muted)', 
+            minHeight: '340px',
+            backgroundImage: 'radial-gradient(circle, rgba(255, 255, 255, 0.07) 1px, transparent 1px)',
+            backgroundSize: '24px 24px',
+            backgroundColor: 'var(--color-bg-card)'
+          }}
+        >
+          <div style={{ padding: '20px', borderRadius: '50%', backgroundColor: 'var(--color-bg-input)', border: '1px solid var(--color-border)', marginBottom: '16px', boxShadow: '0 8px 32px rgba(0,0,0,0.08)' }}>
+            <Database className="w-8 h-8" style={{ color: 'var(--color-primary)' }} />
+          </div>
+          <p style={{ fontSize: '0.925rem', color: 'var(--color-text-main)', fontWeight: 600, margin: 0 }}>Interactive Schema Canvas</p>
+          <p style={{ fontSize: '0.8rem', opacity: 0.8, marginTop: '6px', margin: 0, maxWidth: '280px' }}>
+            Chat with the AI on the left to design and visualize your collections here in real-time.
+          </p>
+        </div>
+      ) : viewMode === 'canvas' ? (
+        /* ── Canvas ERD View ── */
+        <div 
+          ref={containerRef}
+          onMouseDown={handleMouseDown}
+          onWheel={handleWheel}
+          style={{ 
+            flex: 1, 
+            position: 'relative', 
+            overflow: 'hidden', 
+            cursor: isPanning ? 'grabbing' : 'grab',
+            backgroundColor: 'var(--color-bg-card)',
+            backgroundImage: 'radial-gradient(circle, rgba(255, 255, 255, 0.1) 1.2px, transparent 1.2px)',
+            backgroundSize: `${24 * zoom}px ${24 * zoom}px`,
+            backgroundPosition: `${pan.x}px ${pan.y}px`
+          }}
+        >
+          {/* Insert Results Alert (Pinned on Top) */}
+          {insertResults && (
+            <div style={{ position: 'absolute', top: '16px', left: '16px', right: '16px', zIndex: 20, padding: '1rem 1.25rem', backgroundColor: 'var(--color-bg-input)', border: '1px solid var(--color-border)', borderRadius: '12px', boxShadow: '0 8px 32px rgba(0,0,0,0.3)', backdropFilter: 'blur(10px)' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
+                <p style={{ fontSize: '0.85rem', fontWeight: 600, color: 'var(--color-text-main)', margin: 0 }}>Creation Results</p>
+                <button
+                  type="button"
+                  onClick={onNavigateToDb}
+                  className="btn btn-primary"
+                  style={{ padding: '3px 10px', fontSize: '0.75rem', borderRadius: '6px', display: 'flex', alignItems: 'center', gap: '4px' }}
+                >
+                  Continue to Database <ArrowRight size={12} />
+                </button>
+              </div>
+              <ul className="space-y-2" style={{ margin: 0, padding: 0, listStyle: 'none' }}>
+                {insertResults.map((r, i) => (
+                  <li key={i} style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '0.8rem', color: r.success ? 'var(--color-success)' : 'var(--color-danger)' }}>
+                    <span>{r.success ? '✓' : '✗'}</span>
+                    <strong style={{ color: 'var(--color-text-main)' }}>{r.collection}</strong>
+                    {!r.success && <span style={{ color: 'var(--color-danger)', fontSize: '0.75rem' }}>({r.error})</span>}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Floating Zoom & Canvas Controls */}
+          <div 
+            style={{ 
+              position: 'absolute', 
+              bottom: '16px', 
+              right: '16px', 
+              zIndex: 15, 
+              display: 'flex', 
+              alignItems: 'center', 
+              gap: '4px',
+              backgroundColor: 'var(--color-bg-card)',
+              padding: '4px 6px',
+              borderRadius: '10px',
+              border: '1px solid var(--color-border)',
+              boxShadow: '0 4px 16px rgba(0,0,0,0.2)'
+            }}
+          >
+            <button
+              type="button"
+              onClick={handleZoomOut}
+              style={{ padding: '4px', borderRadius: '6px', background: 'transparent', border: 'none', color: 'var(--color-text-muted)', cursor: 'pointer' }}
+              title="Zoom out"
+            >
+              <ZoomOut size={14} />
+            </button>
+            <span style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--color-text-main)', minWidth: '38px', textAlign: 'center', userSelect: 'none' }}>
+              {Math.round(zoom * 100)}%
+            </span>
+            <button
+              type="button"
+              onClick={handleZoomIn}
+              style={{ padding: '4px', borderRadius: '6px', background: 'transparent', border: 'none', color: 'var(--color-text-muted)', cursor: 'pointer' }}
+              title="Zoom in"
+            >
+              <ZoomIn size={14} />
+            </button>
+            <div style={{ width: '1px', height: '14px', backgroundColor: 'var(--color-border)', margin: '0 2px' }} />
+            <button
+              type="button"
+              onClick={handleResetView}
+              style={{ padding: '4px', borderRadius: '6px', background: 'transparent', border: 'none', color: 'var(--color-text-muted)', cursor: 'pointer' }}
+              title="Reset view (1:1)"
+            >
+              <Maximize2 size={14} />
+            </button>
+          </div>
+
+          {/* Transformable Canvas Surface */}
+          <div
+            style={{
+              transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+              transformOrigin: '0 0',
+              transition: isPanning ? 'none' : 'transform 0.15s ease-out',
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: '32px',
+              alignItems: 'flex-start',
+              padding: '24px',
+              minWidth: '1200px'
+            }}
+          >
+            {schema.map((col, idx) => {
+              const isTargetedByRef = hoveredRef === col.collection;
+              return (
+                <div
+                  key={idx}
+                  className="canvas-node"
+                  style={{
+                    width: '320px',
+                    backgroundColor: 'var(--color-bg-card)',
+                    border: '1px solid',
+                    borderColor: isTargetedByRef ? 'var(--color-primary)' : 'var(--color-border)',
+                    borderRadius: '14px',
+                    overflow: 'hidden',
+                    boxShadow: isTargetedByRef 
+                      ? '0 0 24px rgba(62, 207, 142, 0.35)' 
+                      : '0 12px 32px rgba(0,0,0,0.2)',
+                    transition: 'all 0.2s ease',
+                    flexShrink: 0,
+                    userSelect: 'text'
+                  }}
+                >
+                  {/* Node Header */}
+                  <div 
+                    style={{ 
+                      padding: '12px 16px', 
+                      backgroundColor: 'var(--color-bg-input)', 
+                      borderBottom: '1px solid var(--color-border)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between'
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                      <div 
+                        style={{ 
+                          width: '26px', 
+                          height: '26px', 
+                          borderRadius: '6px', 
+                          backgroundColor: 'rgba(62, 207, 142, 0.15)', 
+                          display: 'flex', 
+                          alignItems: 'center', 
+                          justifyContent: 'center',
+                          color: 'var(--color-primary)'
+                        }}
+                      >
+                        <Database size={14} />
+                      </div>
+                      <span style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--color-text-main)', fontFamily: 'monospace' }}>
+                        {col.collection}
+                      </span>
+                    </div>
+
+                    <span 
+                      style={{ 
+                        fontSize: '0.7rem', 
+                        fontWeight: 600, 
+                        color: 'var(--color-text-muted)',
+                        backgroundColor: 'var(--color-bg-card)',
+                        padding: '2px 7px',
+                        borderRadius: '10px',
+                        border: '1px solid var(--color-border)'
+                      }}
+                    >
+                      {(col.fields?.length || 0) + 1} fields
+                    </span>
+                  </div>
+
+                  {/* Node Fields List */}
+                  <div style={{ padding: '4px 0', backgroundColor: 'var(--color-bg-card)' }}>
+                    {/* Implicit _id Primary Key */}
+                    <div 
+                      style={{ 
+                        display: 'flex', 
+                        alignItems: 'center', 
+                        justifyContent: 'space-between',
+                        padding: '7px 16px',
+                        borderBottom: '1px solid rgba(255, 255, 255, 0.04)',
+                        fontSize: '0.8rem'
+                      }}
+                    >
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                        <Key size={11} style={{ color: '#fbbf24' }} title="Primary Key" />
+                        <span style={{ fontFamily: 'monospace', color: 'var(--color-text-main)', fontWeight: 600 }}>
+                          _id
+                        </span>
+                      </div>
+                      <span
+                        style={{
+                          backgroundColor: 'rgba(251, 191, 36, 0.12)',
+                          color: '#fbbf24',
+                          border: '1px solid rgba(251, 191, 36, 0.25)',
+                          borderRadius: '4px',
+                          padding: '1px 6px',
+                          fontSize: '0.65rem',
+                          fontFamily: 'monospace',
+                          fontWeight: 600
+                        }}
+                      >
+                        ObjectId
+                      </span>
+                    </div>
+
+                    {/* Explicit Collection Fields */}
+                    {col.fields?.map((f, fIdx) => (
+                      <div 
+                        key={fIdx}
+                        style={{ 
+                          display: 'flex', 
+                          alignItems: 'center', 
+                          justifyContent: 'space-between',
+                          padding: '7px 16px',
+                          borderBottom: fIdx < col.fields.length - 1 ? '1px solid rgba(255, 255, 255, 0.04)' : 'none',
+                          fontSize: '0.8rem'
+                        }}
+                      >
+                        {/* Field Name + Indicators */}
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flex: 1, overflow: 'hidden' }}>
+                          <span 
+                            style={{ 
+                              fontFamily: 'monospace', 
+                              color: 'var(--color-text-main)',
+                              fontWeight: f.required ? 500 : 400,
+                              whiteSpace: 'nowrap',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis'
+                            }}
+                          >
+                            {f.name}
+                          </span>
+                          {f.required && (
+                            <span style={{ color: 'var(--color-danger)', fontWeight: 700, fontSize: '0.85rem' }} title="Required">*</span>
+                          )}
+                          {f.unique && (
+                            <span style={{ fontSize: '0.6rem', color: 'var(--color-primary)', border: '1px solid var(--color-primary)', padding: '0 3px', borderRadius: '2px', fontWeight: 700 }}>U</span>
+                          )}
+                        </div>
+
+                        {/* Field Type Badge & Ref Link */}
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                          {renderTypeBadge(f)}
+                          {f.type === 'Ref' && f.ref && (
+                            <span
+                              onMouseEnter={() => setHoveredRef(f.ref)}
+                              onMouseLeave={() => setHoveredRef(null)}
+                              style={{
+                                fontSize: '0.7rem',
+                                color: 'var(--color-primary)',
+                                fontWeight: 600,
+                                cursor: 'pointer',
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '2px'
+                              }}
+                              title={`References collection '${f.ref}'`}
+                            >
+                              → {f.ref}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : (
+        /* ── List / Table View ── */
+        <div className="flex-1 overflow-y-auto custom-scrollbar" style={{ padding: '1.5rem', backgroundColor: 'var(--color-bg-card)' }}>
+          {insertResults && (
+            <div style={{ padding: '1.25rem', backgroundColor: 'var(--color-bg-input)', border: '1px solid var(--color-border)', borderRadius: '10px', marginBottom: '1.5rem', animation: 'fadeIn 0.3s ease-out' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
+                <p style={{ fontSize: '0.85rem', fontWeight: 600, color: 'var(--color-text-main)', margin: 0 }}>Insert Results</p>
+                <button
+                  type="button"
+                  onClick={onNavigateToDb}
+                  className="btn btn-primary"
+                  style={{ padding: '4px 12px', fontSize: '0.75rem', borderRadius: '6px', display: 'flex', alignItems: 'center', gap: '4px' }}
+                >
+                  Continue to Database <ArrowRight size={12} />
+                </button>
+              </div>
+              <ul className="space-y-2" style={{ margin: 0, padding: 0, listStyle: 'none' }}>
+                {insertResults.map((r, i) => (
+                  <li key={i} style={{ display: 'flex', alignItems: 'start', gap: '10px', fontSize: '0.8rem', color: r.success ? 'var(--color-success)' : 'var(--color-danger)' }}>
+                    <span style={{ marginTop: '1px', fontWeight: 700 }}>{r.success ? '✓' : '✗'}</span>
+                    <span style={{ color: 'var(--color-text-main)' }}>
+                      <strong style={{ fontWeight: 600 }}>{r.collection}</strong>
+                      {!r.success && <span style={{ display: 'block', color: 'var(--color-danger)', fontSize: '0.75rem', marginTop: '4px' }}>{r.error}</span>}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="space-y-6">
+            {schema.map((col, idx) => (
+              <div key={idx} style={{ backgroundColor: 'var(--color-bg-input)', border: '1px solid var(--color-border)', borderRadius: '12px', overflow: 'hidden', animation: 'fadeIn 0.4s ease-out' }}>
+                <div style={{ padding: '12px 18px', borderBottom: '1px solid var(--color-border)', fontSize: '0.85rem', fontWeight: 600, color: 'var(--color-text-main)', fontFamily: 'monospace', display: 'flex', alignItems: 'center' }}>
+                  <span style={{ color: 'var(--color-primary)', marginRight: '10px', fontSize: '1.1rem' }}>⛁</span>
+                  {col.collection}
+                </div>
+                <div>
+                  <table style={{ width: '100%', textAlign: 'left', fontSize: '0.8rem', borderCollapse: 'collapse' }}>
+                    <tbody style={{ display: 'block', width: '100%' }}>
+                      {col.fields?.map((f, i) => (
+                        <tr key={i} style={{ display: 'flex', width: '100%', borderBottom: i < col.fields.length - 1 ? '1px solid var(--color-border)' : 'none' }}>
+                          <td style={{ padding: '12px 18px', fontFamily: 'monospace', color: 'var(--color-text-main)', width: '50%', borderRight: '1px solid var(--color-border)' }}>
+                            {f.name}
+                            {f.fields && f.fields.length > 0 && (
+                              <div style={{ marginTop: '6px', paddingLeft: '12px', borderLeft: '2px solid rgba(62,207,142,0.3)', fontSize: '0.75rem', color: 'var(--color-text-muted)' }}>
+                                {f.fields.map((sub, sIdx) => (
+                                  <div key={sIdx} style={{ padding: '2px 0' }}>
+                                    <code>{sub.name}</code>: <span style={{ opacity: 0.8 }}>{sub.type}</span>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </td>
+                          <td style={{ padding: '12px 18px', color: 'var(--color-text-muted)', width: '50%', display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
+                            {renderTypeBadge(f)}
+                            {f.type === 'Ref' && f.ref && (
+                              <span style={{ fontSize: '0.7rem', color: 'var(--color-primary)', fontWeight: 500 }}>→ {f.ref}</span>
+                            )}
+                            {f.unique && (
+                              <span style={{ fontSize: '0.65rem', color: 'var(--color-primary)', border: '1px solid var(--color-primary)', padding: '1px 5px', borderRadius: '3px', fontWeight: 600 }}>UNIQUE</span>
+                            )}
+                            {f.required && (
+                              <span style={{ color: 'var(--color-danger)', marginLeft: 'auto', fontWeight: 700, fontSize: '0.9rem' }} title="Required">*</span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 Overview
This PR delivers a full-stack architectural overhaul and UI/UX modernization of the **AI Collection Creator** across the Python microservice, Dashboard API, and Web Dashboard.

Key highlights include:
1. **Interactive ERD Schema Canvas Visualizer** with pan, zoom, reference node highlighting, and dual view (Canvas ⇋ Table).
2. **Session Lifecycle & Rate-Limiting Fixes**: Resolves permanent lockout bug by attaching a 2-hour TTL to Redis iteration counters and cleaning up stale sessions.
3. **Pydantic Model & Prompt Enhancements**: Adds support for `items` (Arrays), `fields` (nested Objects), and `unique` attributes so LLM schema intent is never lost.
4. **ChatGPT-Style Open Workspace**: Clean, unboxed floating chat workspace with auto-growing textarea and quick-start suggestion chips.

---

## 🛠️ Changes by Layer

### 1. 🐍 Python AI Microservice (`apps/python-service`)
- **Pydantic Model Upgrades (`routers/ai.py`)**:
  - Added `items: dict | None`, `fields: list[CollectionField] | None`, and `unique: bool = False` to `CollectionField`.
  - Nested objects and array item types are now strictly validated and passed to consumers without truncation.
- **Refined System Prompt**:
  - Explicit instructions for `Array` items format (e.g. `{"type": "String"}`) and `Object` sub-schemas.
  - Upgraded model assertions to `llama-3.3-70b-versatile`.
- **Test Suite Updates**: Updated `test_byok.py` and `test_collection_creator.py` to match the latest structured output specifications.

### 2. ⚡ Dashboard API (`apps/dashboard-api`)
- **Session Lifecycle & Rate Limiting (`ai.controller.js`)**:
  - Added `EX 7200` (2 hours) TTL to `ai:cc:iterations:{projectId}:{devId}` to prevent permanent lockout after 3 turns.
  - Updated `clearCollectionCreatorSession` to atomically flush both the chat transcript and iteration counter.
  - Added auto-recovery logic: if a session expired, any leftover iteration counter is reset to 0.
  - Returned `iterationLimit` dynamically in the API response.
- **Code Quality & Security**:
  - Consolidated duplicate `Project.findOne` queries in `queryBuilder` into a single query with selected BYOK fields.
  - Moved `mongoose` require to module level.
  - Added explicit warning logs if BYOK decryption returns null.

### 3. 🎨 Web Dashboard (`apps/web-dashboard`)
- **Interactive Schema Canvas Visualizer (`SchemaCanvasViewer.jsx`)**:
  - **Dot-Grid Canvas Workspace**: Infinite background with drag-to-pan and mouse-wheel / button zoom controls (`0.45x` to `1.6x`).
  - **Database Entity Node Cards**: Clean ERD cards with implicit `_id (ObjectId)` primary key badges and field counts.
  - **Color-Coded Field Type Pills**: Distinct palette for `String`, `Number`, `Boolean`, `Date`, `Ref`, `Array<Type>`, and `Object`.
  - **Interactive Reference Links**: Hovering over `→ collection` highlights and glows the targeted collection node.
  - **Dual-View Switcher**: Instant toggle between `Canvas (ERD)` mode and `Table (List)` mode.
- **AI Chat UX Enhancements (`CollectionCreatorAgent.jsx`)**:
  - **Quick-Start Suggestion Chips**: 4 starter prompts (`🛒 E-commerce`, `📋 Project management`, `📝 Blog`, `🎓 Learning platform`) on empty state.
  - **"New Chat" Button**: Clears the conversation and resets server-side session.
  - **Safety Confirmation**: Added confirmation prompt before executing bulk collection creation.
  - **Manual Navigation**: Replaced auto-redirect timers with a "Continue to Database →" button.
  - **Dynamic Iterations Badge**: Dynamic dot counter based on backend limits.

---

## 🧪 Verification & Testing

- [x] **Python Microservice Tests (`pytest`)**: 15 / 15 passed in 6.00s
- [x] **Dashboard API Tests (`jest`)**: 154 / 154 passed
- [x] **Web Dashboard Lint (`eslint`)**: 0 errors, 0 warnings
- [x] **Web Dashboard Build (`vite build`)**: Production bundle built successfully

---

## 📸 Screenshots / Demos
| Feature | Description |
| :--- | :--- |
| **Interactive Canvas** | Visual ERD node cards floating on infinite dot-grid with pan/zoom controls |
| **Dual View** | Toggle between visual Canvas ERD and traditional Table list |
| **Quick Start** | 4 clickable prompt chips on initial chat load |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added canvas and table views for visualizing collection schemas, including nested fields, references, required fields, and unique fields.
  * Added zoom, pan, reset, bulk insertion, and navigation controls.
  * Added quick-start prompts and configurable iteration limits to the collection creator.
  * Added confirmation before bulk collection creation.

* **Bug Fixes**
  * Improved session reset behavior and cleared expired iteration state.
  * Schema validation failures now return a clear 400 response.
  * Added support for nested objects, arrays, and unique collection fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->