### PR TITLE
feat(dashboard): polish collection creator UI, add shadcn components, and support default field values

### DIFF
--- a/apps/python-service/routers/ai.py
+++ b/apps/python-service/routers/ai.py
@@ -46,6 +46,7 @@ class CollectionField(BaseModel):
     required: bool = False
     ref: str | None = None
     unique: bool = False
+    default: Union[str, int, float, bool, None] = None
     items: dict | None = None
     fields: list["CollectionField"] | None = None
 
@@ -182,8 +183,9 @@ Rules:
 1. If the description is vague, ask 2-3 specific clarifying questions and set type: "clarify". You MUST set "schema": null. NEVER ask more than 3 at once.
 2. Once you have enough context, propose a schema and set type: "schema".
 3. Only use these field types: String, Number, Boolean, Date, Ref, Array, Object. For Ref, ALWAYS set 'ref' to the referenced collection name e.g. 'users'. For Array, set 'items' to describe item type e.g. {"type": "String"}. For Object, set 'fields' as a list of sub-fields. Do NOT use Object as a lazy catch-all — prefer specific flat fields when possible.
-4. ALWAYS include "createdAt" (type: Date, required: true) in EVERY collection.
-5. Suggest Ref to "users" where ownership applies (ownerId, authorId, userId, etc.) with 'ref': 'users'.
+4. If a field is NOT required, you may suggest a default value using the 'default' key (value type must exactly match the field type). Do not provide defaults for required fields or complex types.
+5. ALWAYS include "createdAt" (type: Date, required: true) in EVERY collection.
+6. Suggest Ref to "users" where ownership applies (ownerId, authorId, userId, etc.) with 'ref': 'users'.
 6. NEVER generate a collection named "users" — it is reserved for auth.
 7. When the developer confirms satisfaction ("looks good", "yes", "create it", "perfect") -> set type: "complete", set "schema": null, and in your message, clearly tell the developer that their schema is finalized and guide them to click the "Insert All" button in the Schema Preview panel on the right to create the collections in their database. NEVER claim that you have already created the collections yourself.
 8. The "schema" field MUST ALWAYS BE AN ARRAY (LIST) OF OBJECTS. Even if you are proposing a single collection, you must wrap it in an array like: `"schema": [ { "collection": "...", "fields": [...] } ]`. If `type` is "clarify" or "complete", you MUST set `"schema": null`.

--- a/apps/python-service/routers/ai.py
+++ b/apps/python-service/routers/ai.py
@@ -51,10 +51,24 @@ class CollectionField(BaseModel):
     fields: list["CollectionField"] | None = None
 
     @model_validator(mode='after')
-    def validate_object_fields(self):
+    def validate_field(self):
         if self.type == "Object":
             if self.fields is None or len(self.fields) == 0:
                 raise ValueError("fields must be present and non-empty for Object type")
+        
+        if self.default is not None:
+            if self.required:
+                raise ValueError("default is not allowed on required fields")
+            if self.type not in ["String", "Number", "Boolean"]:
+                raise ValueError(f"default is not allowed on {self.type} fields")
+                
+            if self.type == "Boolean" and not isinstance(self.default, bool):
+                raise ValueError("default must be boolean for Boolean fields")
+            elif self.type == "Number" and not (isinstance(self.default, (int, float)) and not isinstance(self.default, bool)):
+                raise ValueError("default must be numeric for Number fields")
+            elif self.type == "String" and not isinstance(self.default, str):
+                raise ValueError("default must be string for String fields")
+                
         return self
 
 class CollectionSchema(BaseModel):

--- a/apps/web-dashboard/package.json
+++ b/apps/web-dashboard/package.json
@@ -15,6 +15,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@radix-ui/react-checkbox": "^1.3.11",
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-select": "^2.3.7",
     "@radix-ui/react-tabs": "^1.1.21",

--- a/apps/web-dashboard/src/components/CollectionCreatorAgent.jsx
+++ b/apps/web-dashboard/src/components/CollectionCreatorAgent.jsx
@@ -166,6 +166,9 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
           if (f.unique !== undefined && !['Array', 'Object', 'Ref'].includes(f.type)) {
             fieldDef.unique = !!f.unique;
           }
+          if (f.default !== undefined) {
+            fieldDef.default = f.default;
+          }
           return fieldDef;
         });
       };

--- a/apps/web-dashboard/src/components/CollectionCreatorAgent.jsx
+++ b/apps/web-dashboard/src/components/CollectionCreatorAgent.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import api from '../utils/api';
 import { toast } from 'react-hot-toast';
-import { Send, ArrowRight } from 'lucide-react';
+import { Send, ArrowRight, Bot } from 'lucide-react';
 import SchemaCanvasViewer from './SchemaCanvasViewer';
 
 const SUGGESTIONS = [
@@ -214,14 +214,22 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
   };
 
   return (
-    <div className="flex flex-col lg:flex-row gap-8 h-full w-full font-sans overflow-hidden">
+    <div className="grid grid-cols-1 lg:grid-cols-[42%_1fr] gap-4 h-full w-full font-sans overflow-hidden">
       
-      {/* Open Chat Stream & Pinned Composer - Left */}
-      <div className="flex flex-col flex-1 h-full min-w-0 overflow-hidden relative">
+      {/* AI Assistant Chat Panel - Left */}
+      <div className="flex flex-col h-full min-w-0 rounded-xl overflow-hidden shadow-sm border border-[var(--color-border)] bg-[var(--color-bg-card)] relative">
         
+        {/* Title Bar matching right side */}
+        <div className="p-3 px-5 border-b border-[var(--color-border)] bg-[var(--color-bg-card)] flex justify-between items-center flex-shrink-0 gap-4 min-h-[56px] z-10">
+          <h3 className="text-sm font-semibold text-[var(--color-text-main)] flex items-center gap-2.5 m-0">
+            <Bot size={16} className="text-[var(--color-primary)]" />
+            <span>AI Schema Assistant</span>
+          </h3>
+        </div>
+
         {/* Messages Stream (Only this scrolls) */}
         <div 
-          className="flex-1 overflow-y-auto custom-scrollbar pr-3 flex flex-col gap-4 min-h-0"
+          className="flex-1 overflow-y-auto custom-scrollbar p-4 flex flex-col gap-5 min-h-0"
         >
           {messages.map((msg) => (
             <div key={msg.id} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
@@ -248,21 +256,20 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
 
           {/* Quick Start Suggestions on empty chat */}
           {messages.length <= 1 && !schema && (
-            <div className="mt-2 flex flex-col gap-2.5">
-              <span className="text-[11px] font-semibold text-[var(--color-text-muted)] uppercase tracking-wider pl-1">
+            <div className="mt-5 flex flex-col gap-2.5">
+              <span className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-wider mb-1">
                 Quick Start Ideas
               </span>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+              <div className="flex flex-wrap gap-2">
                 {SUGGESTIONS.map((s, i) => (
                   <button
                     key={i}
                     type="button"
                     onClick={() => sendMessage(null, s.prompt)}
                     disabled={aiStatus === 'loading' || iterationsLeft === 0}
-                    className="text-left p-3 px-3.5 bg-[var(--color-bg-card)] border border-[var(--color-border)] hover:border-[var(--color-primary)] rounded-xl text-xs font-medium text-[var(--color-text-main)] flex items-center justify-between gap-3 transition-all cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shadow-sm hover:shadow"
+                    className="text-left px-4 py-2 bg-[var(--color-bg-input)] border border-[var(--color-border)] hover:border-[var(--color-primary)] hover:bg-[var(--color-primary)]/5 rounded-full text-xs font-medium text-[var(--color-text-main)] hover:text-[var(--color-primary)] transition-all cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
                   >
-                    <span className="truncate">{s.label}</span>
-                    <ArrowRight size={13} className="opacity-50 shrink-0" />
+                    {s.label}
                   </button>
                 ))}
               </div>
@@ -270,8 +277,8 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
           )}
 
           {aiStatus === 'loading' && (
-            <div className="flex justify-start">
-              <div className="bg-[var(--color-bg-card)] p-3 px-4 rounded-xl rounded-bl-sm border border-[var(--color-border)] flex items-center gap-3 shadow-sm">
+            <div className="flex justify-start mt-2">
+              <div className="bg-[rgba(255,255,255,0.03)] p-3 px-4 rounded-xl rounded-bl-sm border border-[var(--color-border)] flex items-center gap-3 shadow-sm">
                 <div className="spinner-small w-4 h-4 border-t-[var(--color-primary)]"></div>
                 <span className="text-xs text-[var(--color-text-muted)] font-medium">
                   AI is designing your schema...
@@ -283,9 +290,9 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
         </div>
         
         {/* Pinned Bottom Composer */}
-        <div className="mt-auto pt-3 flex-shrink-0">
+        <div className="px-4 pb-4 pt-2 bg-[var(--color-bg-card)] flex-shrink-0">
           <div 
-            className="relative flex items-end bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-xl p-2.5 px-4 shadow-lg transition-all focus-within:border-[var(--color-primary)] focus-within:ring-1 focus-within:ring-[var(--color-primary)]/30"
+            className="relative flex items-end bg-[var(--color-bg-input)] border border-[var(--color-border)] rounded-xl p-2 pl-4 shadow-sm transition-all focus-within:border-[var(--color-primary)] focus-within:ring-1 focus-within:ring-[var(--color-primary)]/30"
           >
             <textarea 
               ref={textareaRef}
@@ -293,19 +300,19 @@ export default function CollectionCreatorAgent({ projectId, onInsertAll }) {
               onChange={(e) => setInputValue(e.target.value)}
               onKeyDown={handleKeyDown}
               disabled={aiStatus === 'loading' || (iterationsLeft === 0)}
-              placeholder={iterationsLeft === 0 ? "Turn limit reached. Add Groq key in Settings." : "Describe your app (e.g. e-commerce store, booking system, CRM...)"}
+              placeholder={iterationsLeft === 0 ? "Turn limit reached. Add Groq key in Settings." : "Describe your app (e.g. e-commerce store, CRM)..."}
               aria-label="Message the schema assistant"
               rows={1}
-              className="w-full bg-transparent border-0 outline-none text-[var(--color-text-main)] text-sm leading-relaxed resize-none max-h-[110px] min-h-[26px] py-1 placeholder:text-[var(--color-text-muted)]"
+              className="w-full bg-transparent border-0 outline-none text-[var(--color-text-main)] text-sm leading-relaxed resize-none max-h-[110px] min-h-[26px] py-1.5 pl-2 pr-10 placeholder:text-[var(--color-text-muted)]"
             />
             <button 
               type="button"
               onClick={sendMessage}
               disabled={!inputValue.trim() || aiStatus === 'loading' || (iterationsLeft === 0)}
-              className="flex items-center justify-center w-8 h-8 rounded-lg bg-[var(--color-primary)] text-black border-0 cursor-pointer disabled:opacity-35 disabled:cursor-not-allowed transition-all shrink-0 ml-2.5 font-semibold"
+              className="absolute right-3 bottom-2.5 flex items-center justify-center w-8 h-8 rounded-xl bg-[var(--color-primary)] text-black border-0 cursor-pointer disabled:opacity-35 disabled:cursor-not-allowed transition-all font-semibold shadow-sm"
               title="Send message (Enter)"
             >
-              <Send size={14} />
+              <Send size={15} />
             </button>
           </div>
           {getIterationsBadge()}

--- a/apps/web-dashboard/src/components/SchemaCanvasViewer.jsx
+++ b/apps/web-dashboard/src/components/SchemaCanvasViewer.jsx
@@ -50,6 +50,7 @@ export default function SchemaCanvasViewer({
       type: f.type,
       required: !!f.required,
       unique: !!f.unique,
+      default: f.default,
       ref: f.ref,
       items: f.items,
       fields: f.fields
@@ -175,7 +176,7 @@ export default function SchemaCanvasViewer({
   return (
     <TooltipProvider>
       <div 
-        className="flex flex-col flex-1 lg:flex-[1.25] h-full min-w-0 rounded-2xl overflow-hidden shadow-sm border border-[var(--color-border)] bg-[var(--color-bg-card)] relative"
+        className="flex flex-col h-full min-w-0 rounded-xl overflow-hidden shadow-sm border border-[var(--color-border)] bg-[var(--color-bg-card)] relative"
       >
         {/* Top Header & Tabs Toolbar (Spacious & Clean) */}
         <div className="p-3 px-5 border-b border-[var(--color-border)] bg-[var(--color-bg-card)] flex justify-between items-center flex-shrink-0 gap-4 flex-wrap z-10 min-h-[56px]">
@@ -291,8 +292,8 @@ export default function SchemaCanvasViewer({
               <p className="text-xs text-[var(--color-text-muted)] max-w-xs leading-relaxed mb-4">
                 Describe your application idea in the chat on the left. The AI architect will design your MongoDB collections and render an interactive canvas here.
               </p>
-              <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-[var(--color-bg-input)] border border-[var(--color-border)] text-[11px] text-[var(--color-text-muted)] font-mono">
-                <span>Example: "A multi-tenant SaaS with workspaces, projects, and invoices"</span>
+              <div className="text-[11px] text-[var(--color-text-muted)] opacity-70 italic">
+                Example: "A multi-tenant SaaS with workspaces, projects, and invoices"
               </div>
             </div>
           ) : viewMode === 'canvas' ? (

--- a/apps/web-dashboard/src/components/ui/checkbox.jsx
+++ b/apps/web-dashboard/src/components/ui/checkbox.jsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "../../lib/utils"
+
+const Checkbox = React.forwardRef(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-[var(--color-border)] bg-[var(--color-bg-input)] shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-primary)] disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-[var(--color-primary)] data-[state=checked]:text-black",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-3 w-3 font-bold" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/apps/web-dashboard/src/components/ui/input.jsx
+++ b/apps/web-dashboard/src/components/ui/input.jsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+import { cn } from "../../lib/utils"
+
+const Input = React.forwardRef(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-9 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] px-3 py-2 text-sm text-[var(--color-text-main)] shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-[var(--color-text-muted)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-primary)] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Input.displayName = "Input"
+
+export { Input }

--- a/apps/web-dashboard/src/index.css
+++ b/apps/web-dashboard/src/index.css
@@ -164,10 +164,12 @@
   box-shadow: none !important;
 }
 
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
+@layer base {
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
 }
 
 body {

--- a/apps/web-dashboard/src/pages/CreateCollection.jsx
+++ b/apps/web-dashboard/src/pages/CreateCollection.jsx
@@ -6,6 +6,10 @@ import toast from 'react-hot-toast';
 import { Plus, Trash2, ArrowLeft, ChevronDown, ChevronRight, Wand2 } from 'lucide-react';
 import CollectionCreatorAgent from '../components/CollectionCreatorAgent';
 import { Tabs, TabsList, TabsTrigger } from '../components/ui/tabs';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
+import { Input } from '../components/ui/input';
+import { Checkbox } from '../components/ui/checkbox';
+import { Button } from '../components/ui/button';
 
 const MAX_DEPTH = 3;
 
@@ -137,6 +141,7 @@ function CreateCollection() {
         const normalizedName = name.trim().toLowerCase();
 
         if (!normalizedName) return toast.error("Collection name is required");
+        if (fields.length === 0) return toast.error("Collection must have at least one field");
         if (fields.some(f => !f.key)) return toast.error("All fields must have a name");
 
         if (normalizedName === 'users') {
@@ -168,7 +173,8 @@ function CreateCollection() {
 
     return (
         <div 
-            className="w-full flex-1 flex flex-col min-h-0 overflow-y-auto overflow-x-hidden box-border p-6 lg:p-8"
+            className="w-full flex flex-col overflow-hidden box-border p-4"
+            style={{ height: 'calc(100vh - var(--header-height))' }}
         >
             {/* Top Navigation & Mode Switch Header (Pinned, Non-overlapping) */}
             <div 
@@ -203,51 +209,55 @@ function CreateCollection() {
             </div>
 
             {mode === 'manual' ? (
-                <div className="flex-1 overflow-y-auto custom-scrollbar max-w-6xl mx-auto w-full py-6">
-                    <div className="bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-xl p-8 shadow-sm">
-                        <div className="form-group mb-8">
-                            <label className="form-label text-sm font-semibold text-[var(--color-text-muted)] uppercase tracking-wider mb-3 block">
-                                Collection Name
-                            </label>
-                            <input
-                                type="text"
-                                value={name}
-                                onChange={(e) => setName(e.target.value)}
-                                disabled={initialName === 'users'}
-                                className="input-field w-full text-base font-mono py-2"
-                                style={{
-                                    cursor: initialName === 'users' ? 'not-allowed' : 'text',
-                                    opacity: initialName === 'users' ? 0.7 : 1
-                                }}
-                                placeholder="e.g. products, orders, articles"
-                                autoFocus={initialName !== 'users'}
-                            />
-                            <small className="text-sm text-[var(--color-text-muted)] mt-2 block">
-                                This will be the name of your collection in the database.
-                            </small>
-                        </div>
-
-                        <div className="mt-8">
-                            <div className="flex justify-between items-center mb-3">
-                                <h3 className="text-sm font-semibold text-[var(--color-text-main)] m-0">Fields</h3>
-                                <button
-                                    type="button"
-                                    onClick={addField}
-                                    className="btn btn-secondary text-xs px-3 py-1.5 flex items-center gap-1.5 rounded-md"
-                                >
-                                    <Plus size={13} /> Add Field
-                                </button>
+                <div className="flex-1 overflow-y-auto custom-scrollbar w-full flex flex-col">
+                    <div className="w-full max-w-4xl mx-auto py-8 my-auto flex flex-col justify-center">
+                        <div className="bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-2xl p-8 shadow-sm">
+                            <div className="form-group mb-8">
+                                <label className="form-label text-sm font-semibold text-[var(--color-text-muted)] uppercase tracking-wider mb-3 block">
+                                    Collection Name
+                                </label>
+                                <Input
+                                    type="text"
+                                    value={name}
+                                    onChange={(e) => setName(e.target.value)}
+                                    disabled={initialName === 'users'}
+                                    className="w-full text-base font-mono py-5"
+                                    style={{
+                                        cursor: initialName === 'users' ? 'not-allowed' : 'text',
+                                        opacity: initialName === 'users' ? 0.7 : 1
+                                    }}
+                                    placeholder="e.g. products, orders, articles"
+                                    autoFocus={initialName !== 'users'}
+                                />
+                                <small className="text-sm text-[var(--color-text-muted)] mt-2 block">
+                                    This will be the name of your collection in the database.
+                                </small>
                             </div>
 
-                            <div className="flex items-center gap-2 px-3 py-3 mb-2 text-xs font-semibold text-[var(--color-text-muted)] tracking-wider">
-                                <span className="flex-2">NAME</span>
-                                <span className="flex-1">TYPE</span>
-                                <span className="w-6 text-center">REQ</span>
-                                <span className="w-6 text-center">UNIQ</span>
-                                <span className="w-8"></span>
-                            </div>
+                            <div className="mt-8">
+                                <div className="flex justify-between items-center mb-4">
+                                    <h3 className="text-sm font-semibold text-[var(--color-text-main)] m-0">Fields</h3>
+                                    <Button
+                                        type="button"
+                                        variant="secondary"
+                                        size="sm"
+                                        onClick={addField}
+                                        className="text-xs px-3 py-1.5 flex items-center gap-1.5 rounded-md h-8"
+                                    >
+                                        <Plus size={13} /> Add Field
+                                    </Button>
+                                </div>
 
-                            <div className="border border-[var(--color-border)] rounded-lg overflow-hidden bg-[var(--color-bg-input)] divide-y divide-[var(--color-border)]">
+                                <div className="flex items-center gap-3 px-3 py-3 mb-2 text-xs font-semibold text-[var(--color-text-muted)] tracking-wider">
+                                    <span className="flex-[3]">NAME</span>
+                                    <span className="flex-[2]">TYPE</span>
+                                    <span className="flex-[2]">DEFAULT</span>
+                                    <span className="w-12 text-center flex justify-center" title="Required">REQ</span>
+                                    <span className="w-12 text-center flex justify-center" title="Unique">UNIQ</span>
+                                    <span className="w-8"></span>
+                                </div>
+
+                                <div className="space-y-1.5">
                                 {fields.map((field, index) => (
                                     <FieldRow
                                         key={field._id}
@@ -270,18 +280,19 @@ function CreateCollection() {
                         </div>
 
                         <div className="mt-8 pt-4 border-t border-[var(--color-border)] flex justify-end">
-                            <button
+                            <Button
                                 onClick={handleSubmit}
-                                className="btn btn-primary text-xs px-6 py-2 font-semibold"
+                                className="px-6 py-2 h-10 font-semibold"
                                 disabled={loading}
                             >
                                 {loading ? 'Creating...' : 'Save Collection'}
-                            </button>
+                            </Button>
                         </div>
                     </div>
                 </div>
+            </div>
             ) : (
-                <div className="flex-1 overflow-hidden min-h-0 w-full">
+                <div className="flex-1 overflow-hidden min-h-0 w-full flex flex-col">
                     <CollectionCreatorAgent 
                         projectId={projectId} 
                         onInsertAll={() => {
@@ -332,7 +343,14 @@ function FieldRow({
         onChange(index, nextField);
     };
 
-    const handleRequiredToggle = () => onChange(index, { ...field, required: !field.required });
+    const handleRequiredToggle = (e) => {
+        const checked = e.target.checked;
+        const newField = { ...field, required: checked };
+        if (checked) {
+            delete newField.default;
+        }
+        onChange(index, newField);
+    };
     const handleUniqueToggle = () => onChange(index, { ...field, unique: !field.unique });
     const handleRefChange = (e) => onChange(index, { ...field, ref: e.target.value });
 
@@ -362,9 +380,30 @@ function FieldRow({
         onChange(index, { ...field, items: nextItems });
     };
 
+    const handleDefaultChange = (e) => {
+        let val = e.target.value;
+        const newField = { ...field };
+        
+        if (val === '') {
+            delete newField.default;
+            onChange(index, newField);
+            return;
+        }
+
+        if (field.type === 'Number') {
+            const num = Number(val);
+            newField.default = isNaN(num) ? val : num;
+        } else {
+            newField.default = val;
+        }
+        onChange(index, newField);
+    };
+
+    const isDefaultSupported = !field.required && !isObject && !isArray && !isRef && field.key !== '_id';
+
     return (
-        <div className="text-xs bg-[var(--color-bg-card)]">
-            <div className="flex items-center gap-2 p-2 px-3 hover:bg-[var(--color-surface-hover)] transition-colors">
+        <div className="text-sm bg-transparent">
+            <div className="flex items-center gap-3 p-2 px-3 hover:bg-[var(--color-bg-card)] rounded-lg transition-colors border border-transparent hover:border-[var(--color-border)]">
                 {/* Collapse / Expand icon for complex types */}
                 <div className="w-5 flex items-center justify-center">
                     {(isObject || (isArray && field.items?.type === 'Object')) ? (
@@ -381,83 +420,132 @@ function FieldRow({
                 </div>
 
                 {/* Field Name */}
-                <div className="flex-2">
-                    <input
+                <div className="flex-[3]">
+                    <Input
                         type="text"
                         value={field.key}
                         onChange={handleKeyChange}
                         disabled={isFixed}
                         placeholder="field_name"
-                        className="input-field w-full text-sm font-mono py-2 px-3 h-9"
+                        className="w-full text-sm font-mono h-9"
                     />
                 </div>
 
                 {/* Field Type Selector */}
-                <div className="flex-1">
-                    <select
+                <div className="flex-[2]">
+                    <Select
                         value={field.type}
-                        onChange={handleTypeChange}
+                        onValueChange={(val) => handleTypeChange({ target: { value: val } })}
                         disabled={isFixed}
-                        className="input-field w-full text-sm py-2 px-3 h-9"
                     >
-                        {ALL_TYPES.map(t => (
-                            <option key={t} value={t}>{t}</option>
-                        ))}
-                    </select>
+                        <SelectTrigger className="w-full text-sm h-9">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {ALL_TYPES.map(t => (
+                                <SelectItem key={t} value={t} className="text-sm">{t}</SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
                 </div>
 
                 {/* Ref Collection Dropdown */}
                 {isRef && (
                     <div className="flex-1">
-                        <select
+                        <Select
                             value={field.ref || 'users'}
-                            onChange={handleRefChange}
-                            className="input-field w-full text-sm py-2 px-3 h-9 font-mono text-cyan-400"
+                            onValueChange={(val) => handleRefChange({ target: { value: val } })}
                         >
-                            <option value="users">users (Auth)</option>
-                            {collections.filter(c => c.name !== 'users').map(c => (
-                                <option key={c.name} value={c.name}>{c.name}</option>
-                            ))}
-                        </select>
+                            <SelectTrigger className="w-full text-sm h-9 font-mono text-cyan-400">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="users" className="font-mono">users (Auth)</SelectItem>
+                                {collections.filter(c => c.name !== 'users').map(c => (
+                                    <SelectItem key={c.name} value={c.name} className="font-mono">{c.name}</SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
                     </div>
                 )}
 
                 {/* Array Item Type Selector */}
                 {isArray && (
-                    <div className="flex-1 flex items-center gap-1.5">
+                    <div className="flex-[2] flex items-center gap-2">
                         <span className="text-[11px] font-semibold text-[var(--color-text-muted)]">OF</span>
-                        <select
+                        <Select
                             value={field.items?.type || 'String'}
-                            onChange={handleArrayItemTypeChange}
-                            className="input-field w-full text-sm py-2 px-3 h-9"
+                            onValueChange={(val) => handleArrayItemTypeChange({ target: { value: val } })}
                         >
-                            {ARRAY_ITEM_TYPES.map(t => (
-                                <option key={t} value={t}>{t}</option>
-                            ))}
-                        </select>
+                            <SelectTrigger className="w-full text-sm h-9">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {ARRAY_ITEM_TYPES.map(t => (
+                                    <SelectItem key={t} value={t} className="text-sm">{t}</SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
                     </div>
                 )}
 
+                {/* Default Value Input */}
+                <div className="flex-[2] flex items-center">
+                    {isDefaultSupported ? (
+                        field.type === 'Boolean' ? (
+                            <Select
+                                value={field.default !== undefined ? String(field.default) : 'none'}
+                                onValueChange={(val) => {
+                                    const newField = { ...field };
+                                    if (val === 'none') {
+                                        delete newField.default;
+                                    } else {
+                                        newField.default = val === 'true';
+                                    }
+                                    onChange(index, newField);
+                                }}
+                                disabled={isFixed}
+                            >
+                                <SelectTrigger className="w-full text-sm h-9">
+                                    <SelectValue placeholder="Default" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="none" className="text-xs italic text-[var(--color-text-muted)]">No default</SelectItem>
+                                    <SelectItem value="true">true</SelectItem>
+                                    <SelectItem value="false">false</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        ) : (
+                            <Input
+                                type={field.type === 'Number' ? 'number' : 'text'}
+                                value={field.default !== undefined ? field.default : ''}
+                                onChange={handleDefaultChange}
+                                disabled={isFixed}
+                                placeholder="Default"
+                                className="w-full text-sm font-mono h-9"
+                            />
+                        )
+                    ) : (
+                        <div className="w-full text-center text-[var(--color-text-muted)] italic text-xs">N/A</div>
+                    )}
+                </div>
+
                 {/* Required Checkbox */}
-                <div className="w-6 text-center">
-                    <input
-                        type="checkbox"
+                <div className="w-12 flex justify-center text-center">
+                    <Checkbox
                         checked={field.required}
-                        onChange={handleRequiredToggle}
+                        onCheckedChange={(checked) => handleRequiredToggle({ target: { checked } })}
                         disabled={isFixed}
-                        className="cursor-pointer"
                         title="Required"
                     />
                 </div>
 
                 {/* Unique Checkbox */}
-                <div className="w-6 text-center">
-                    <input
-                        type="checkbox"
+                <div className="w-12 flex justify-center text-center">
+                    <Checkbox
                         checked={field.unique}
-                        onChange={handleUniqueToggle}
+                        onCheckedChange={(checked) => handleUniqueToggle({ target: { checked } })}
                         disabled={isFixed || isArray || isObject || isRef}
-                        className="cursor-pointer"
                         title="Unique"
                     />
                 </div>

--- a/apps/web-dashboard/src/pages/CreateCollection.jsx
+++ b/apps/web-dashboard/src/pages/CreateCollection.jsx
@@ -108,6 +108,10 @@ function CreateCollection() {
                 required: !!f.required,
             };
 
+            if (f.default !== undefined) {
+                cleaned.default = f.default;
+            }
+
             if (f.unique && !['Array', 'Object', 'Ref'].includes(f.type)) {
                 cleaned.unique = true;
             }
@@ -327,6 +331,7 @@ function FieldRow({
     const handleTypeChange = (e) => {
         const nextType = e.target.value;
         const nextField = { ...field, type: nextType };
+        delete nextField.default;
         if (nextType === 'Object' && (!field.fields || field.fields.length === 0)) {
             nextField.fields = [createEmptyField()];
         }
@@ -399,7 +404,7 @@ function FieldRow({
         onChange(index, newField);
     };
 
-    const isDefaultSupported = !field.required && !isObject && !isArray && !isRef && field.key !== '_id';
+    const isDefaultSupported = !field.required && ['String', 'Number', 'Boolean'].includes(field.type) && field.key !== '_id';
 
     return (
         <div className="text-sm bg-transparent">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1258,6 +1258,7 @@
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@radix-ui/react-checkbox": "^1.3.11",
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-select": "^2.3.7",
         "@radix-ui/react-tabs": "^1.1.21",
@@ -5875,6 +5876,35 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.11.tgz",
+      "integrity": "sha512-Gnptr9pDDQxD3hgq2dtPbtrp/c2qH1mBwIzw3X/ivrMb2e1t0jMTi606fVEqFPaQR1ggXIVQWKj3P2WW9v7zGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-size": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/packages/common/src/utils/input.validation.js
+++ b/packages/common/src/utils/input.validation.js
@@ -232,14 +232,14 @@ const fieldSchemaZod = buildFieldSchemaZod(1);
 module.exports.createCollectionSchema = z.object({
   projectId: z.string().min(1, "Project ID is required"),
   collectionName: z.string().min(1, "Collection Name is required"),
-  schema: z.array(fieldSchemaZod).optional(),
+  schema: z.array(fieldSchemaZod).min(1, "At least one field is required"),
 });
 
 // SCHEMA - EDIT COLLECTION (DASHBOARD)
 module.exports.editCollectionSchema = z.object({
   projectId: z.string().min(1, "Project ID is required"),
   collectionName: z.string().min(1, "Collection Name is required"),
-  schema: z.array(fieldSchemaZod).optional(),
+  schema: z.array(fieldSchemaZod).min(1, "At least one field is required"),
 });
 
 // SYNC SCHEMA (CLI)


### PR DESCRIPTION
## Description

This PR brings significant UI/UX polish to the Collection Creator (both AI-Assisted and Manual modes), migrates the builder to use Shadcn UI components, and introduces the ability to set and generate default values for non-required fields. It also adds safety validations for empty schemas.

### 🎨 UI/UX Layout Fixes
* **Viewport & Grid Hierarchy:** Fixed the CSS height propagation bug. The page now properly inherits `calc(100vh - var(--header-height))` and uses a clean CSS Grid layout (`grid-cols-[42%_1fr]`) instead of flex rows, solving the giant empty space issue at the bottom of the screen.
* **Workspace Spacing:** Added consistent 16px outer padding and exactly 16px (`gap-4`) spacing between the AI Assistant and Schema Architect panels.
* **Composer Anchoring:** The AI chat composer is now naturally anchored to the bottom of the scroll area without artificial fixed positioning.
* **Corner Rounding:** Unified corner styling to a slightly sharper `rounded-xl` / `rounded-lg` across the workspace for a cleaner, more professional developer tool look.

### 🧩 Shadcn UI Integration
* Scrapped all native HTML `<input>`, `<select>`, `<checkbox>`, and `<button>` elements in the manual builder's `FieldRow`.
* Scaffolded and integrated Radix-based Shadcn components (`Input`, `Select`, `Checkbox`, `Button`), significantly improving the aesthetics and interaction quality of the schema builder.
* Removed the massive continuous outer box wrapping all fields and replaced it with clean, independent rows that utilize subtle hover effects.

### ✨ Default Values Support
* **Manual Builder:** Added a new `DEFAULT` column in the schema builder. Developers can now set default values for non-required `String`, `Number`, and `Boolean` fields.
* **AI-Assisted Builder:** Updated the `python-service` Langchain prompts and Pydantic validation rules. The AI will now intelligently suggest default values for optional fields (e.g. `status: "active"`).
* **Smart Validation:** In the UI, toggling a field to `Required` automatically clears any set default value (since required fields cannot have defaults per our engine's schema contract). The `SchemaCanvasViewer` was also updated to render `default` properties visually.

### 🛡️ Safety & Backend Enhancements
* **Enforce Non-Empty Collections:** Added validation at both the UI and Backend API layers to strictly prohibit the creation of collections with 0 fields. 
* Updated `createCollectionSchema` and `editCollectionSchema` in `packages/common/src/utils/input.validation.js` to enforce `z.array().min(1)`.

### How to Test
1. Create a new collection and observe the new Shadcn elements.
2. Add a `String` or `Boolean` field, leave "Required" unchecked, and set a Default value.
3. Check "Required" and verify the default value is automatically cleared.
4. Try to submit a collection with zero fields; verify the UI toast error and the API 400 rejection.
5. In the AI Assistant, prompt: *"Create a tasks collection with a default status of 'todo'"* and verify the AI generates the default value correctly in the canvas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for default values on optional scalar collection fields.
  * Manual collection creation now supports editable defaults, including text, numeric, and boolean values.
  * Added reusable checkbox and input controls.
  * Refreshed the collection creation and AI assistant interfaces with updated layouts, styling, and quick-start suggestions.
  * Schema views now preserve and display field defaults.

* **Bug Fixes**
  * Collection creation and editing now require at least one schema field.
  * Making a field required automatically clears its default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->